### PR TITLE
Fixed loopback ip address flushing

### DIFF
--- a/base_deb/etc/one-context.d/00-network
+++ b/base_deb/etc/one-context.d/00-network
@@ -196,8 +196,10 @@ deactivate_network()
         IFACES=`/sbin/ifquery -la`
 
         for i in $IFACES; do
-            /sbin/ifdown $i
-            /sbin/ip addr flush dev $i
+        	if [ $i != 'lo' ]; then
+            	/sbin/ifdown $i
+            	/sbin/ip addr flush dev $i
+            fi
         done
     else
         service networking stop


### PR DESCRIPTION
```
/sbin/ip addr flush dev lo
```

causes after contextualization, there's no ip on lo interface, tested on ubuntu 12.04, 14.04
