### PR TITLE
Add MTU support to network devices

### DIFF
--- a/base_deb/etc/one-context.d/00-network
+++ b/base_deb/etc/one-context.d/00-network
@@ -52,6 +52,13 @@ get_mask() {
     echo $mask
 }
 
+# Gets device MTU
+get_mtu() {
+    mtu=$(get_iface_var "MTU")
+
+    echo $mtu
+}
+
 is_gateway() {
     if [ -z "$GATEWAY_IFACE_NUM" ]; then
         true
@@ -108,6 +115,10 @@ iface $DEV inet static
   netmask $MASK
 EOT
 
+    if [ -n "$MTU" ]; then
+        echo "  mtu $MTU"
+    fi
+
     if [ -n "$GATEWAY" ]; then
         echo "  gateway $GATEWAY"
     fi
@@ -121,6 +132,10 @@ iface $DEV inet6 static
   address $IPV6
   netmask 64
 EOT
+
+    if [ -n "$MTU" ]; then
+        echo "  mtu $MTU"
+    fi
 
     if [ -n "$GATEWAY6" ]; then
         echo "  gateway $GATEWAY6"
@@ -168,6 +183,7 @@ EOT
         IP=$(get_ip)
         NETWORK=$(get_network)
         MASK=$(get_mask)
+        MTU=$(get_mtu)
         GATEWAY=$(get_gateway)
 
         IPV6=$(get_iface_var "IPV6")

--- a/base_rpm/etc/one-context.d/00-network
+++ b/base_rpm/etc/one-context.d/00-network
@@ -52,6 +52,13 @@ get_mask() {
     echo $mask
 }
 
+# Gets device MTU
+get_mtu() {
+    mtu=$(get_iface_var "MTU")
+
+    echo $mtu
+}
+
 is_gateway() {
     if [ -z "$GATEWAY_IFACE_NUM" ]; then
         true
@@ -105,6 +112,9 @@ gen_iface_conf() {
 NETMASK=$MASK
 IPADDR=$IP
 EOT
+    if [ -n "$MTU" ]; then
+        echo "MTU=$MTU"
+    fi
 
     if [ -n "$GATEWAY" ]; then
         echo "GATEWAY=$GATEWAY"
@@ -118,6 +128,10 @@ gen_iface6_conf() {
 IPV6INIT=yes
 IPV6ADDR=$IPV6
 EOT
+
+    if [ -n "$MTU" ]; then
+        echo "MTU=$MTU"
+    fi
 
     if [ -n "$GATEWAY6" ]; then
         echo "IPV6_DEFAULTGW=$GATEWAY6"
@@ -159,6 +173,7 @@ gen_network_configuration()
         IP=$(get_ip)
         NETWORK=$(get_network)
         MASK=$(get_mask)
+        MTU=$(get_mtu)
         GATEWAY=$(get_gateway)
 
         IPV6=$(get_iface_var "IPV6")


### PR DESCRIPTION
Some hosts configurations can to require to add different MTU values in their guests, for example if you are using openvswitch with gre support, the guests requires MTU=1420.