### PR TITLE
Fix ifquery error on Debian based OS like ubuntu

### DIFF
--- a/base_deb/etc/one-context.d/00-network
+++ b/base_deb/etc/one-context.d/00-network
@@ -209,7 +209,7 @@ deactivate_network()
 {
     . /etc/os-release
     if [ $ID = "ubuntu" ]; then
-        IFACES=`/sbin/ifquery -la`
+        IFACES=`/sbin/ifquery --list -a`
 
         for i in $IFACES; do
             if [ $i != 'lo' ]; then
@@ -226,7 +226,7 @@ activate_network()
 {
     . /etc/os-release
     if [ $ID = "ubuntu" ]; then
-        IFACES=`/sbin/ifquery -la`
+        IFACES=`/sbin/ifquery --list -a`
 
         for i in $IFACES; do
             /sbin/ifup $i


### PR DESCRIPTION
In Ubuntu 12.04 ifquery don't have any option "-l" we need to pass --list instead.
Debian 8 ifquery don't have this "-l" option.