### PR TITLE
Swap script will now swap on all available swap spaces

### DIFF
--- a/base/etc/one-context.d/04-mount-swap
+++ b/base/etc/one-context.d/04-mount-swap
@@ -1,1 +1,15 @@
-swapon -L swap
+#!/bin/bash
+
+activate_swaps() {
+
+    SWAP_DRIVES=$(blkid | grep 'TYPE=\"swap\"' | cut -d':' -f1)
+    for SWAP in $SWAP_DRIVES ; do
+        if [ -z "$(swapon -s | grep $SWAP)"]; then
+            swapon $SWAP
+        fi
+    done
+    
+}
+
+activate_swaps
+

--- a/base/etc/one-context.d/04-mount-swap
+++ b/base/etc/one-context.d/04-mount-swap
@@ -2,9 +2,9 @@
 
 activate_swaps() {
 
-    SWAP_DRIVES=$(blkid | grep 'TYPE=\"swap\"' | cut -d':' -f1)
+    SWAP_DRIVES=$(blkid -t TYPE="swap" -o device)
     for SWAP in $SWAP_DRIVES ; do
-        if [ -z "$(swapon -s | grep $SWAP)"]; then
+        if [ -z "$(swapon -s | grep $SWAP)" ]; then
             swapon $SWAP
         fi
     done


### PR DESCRIPTION
Instead of using the swap label the swap script will find and swapon all available swap spaces.  This allows for images which may not have the swap setup in the fstab to utilize that swap.