### PR TITLE
Create SSH directory before authorized_keys file

### DIFF
--- a/base/etc/one-context.d/02-ssh_public_key
+++ b/base/etc/one-context.d/02-ssh_public_key
@@ -29,9 +29,9 @@ function add_keys {
 
 [ -z "${SSH_PUBLIC_KEY}${EC2_PUBLIC_KEY}" ] && exit 0
 
-[ ! -f $AUTH_FILE ] && touch $AUTH_FILE
-
 mkdir -m0700 -p $AUTH_DIR
+
+[ ! -f $AUTH_FILE ] && touch $AUTH_FILE
 
 if [ -n "$SSH_PUBLIC_KEY" ]; then
     echo "$SSH_PUBLIC_KEY" | add_keys


### PR DESCRIPTION
The ```touch``` will fail if the directory does not exist.