### PR TITLE
Replace unsafe characters in SET_HOSTNAME.

### DIFF
--- a/base_arch/etc/one-context.d/05-hostname
+++ b/base_arch/etc/one-context.d/05-hostname
@@ -20,7 +20,7 @@ function get_dns_name() {
 }
 
 if [ -n "$SET_HOSTNAME" ]; then
-    set_hostname $(echo "$SET_HOSTNAME" | sed -e 's/[^-a-zA-Z0-9]/-/g')
+    set_hostname $(echo "$SET_HOSTNAME" | sed -e 's/[^-a-zA-Z0-9]/-/g' -e 's/^-*//g' -e 's/-*$//g')
 elif [ -n "$DNS_HOSTNAME" ]; then
     set_hostname $(get_dns_name)
 fi

--- a/base_arch/etc/one-context.d/05-hostname
+++ b/base_arch/etc/one-context.d/05-hostname
@@ -20,7 +20,7 @@ function get_dns_name() {
 }
 
 if [ -n "$SET_HOSTNAME" ]; then
-    set_hostname $SET_HOSTNAME
+    set_hostname $(echo "$SET_HOSTNAME" | sed -e 's/[^-a-zA-Z0-9]/-/g')
 elif [ -n "$DNS_HOSTNAME" ]; then
     set_hostname $(get_dns_name)
 fi

--- a/base_deb.one/etc/one-context.d/05-hostname
+++ b/base_deb.one/etc/one-context.d/05-hostname
@@ -22,7 +22,7 @@ function get_dns_name() {
 }
 
 if [ -n "$SET_HOSTNAME" ]; then
-    set_hostname $(echo "$SET_HOSTNAME" | sed -e 's/[^-a-zA-Z0-9]/-/g')
+    set_hostname $(echo "$SET_HOSTNAME" | sed -e 's/[^-a-zA-Z0-9]/-/g' -e 's/^-*//g' -e 's/-*$//g')
 elif [ -n "$DNS_HOSTNAME" ]; then
     set_hostname $(get_dns_name)
 fi

--- a/base_deb.one/etc/one-context.d/05-hostname
+++ b/base_deb.one/etc/one-context.d/05-hostname
@@ -22,7 +22,7 @@ function get_dns_name() {
 }
 
 if [ -n "$SET_HOSTNAME" ]; then
-    set_hostname $SET_HOSTNAME
+    set_hostname $(echo "$SET_HOSTNAME" | sed -e 's/[^-a-zA-Z0-9]/-/g')
 elif [ -n "$DNS_HOSTNAME" ]; then
     set_hostname $(get_dns_name)
 fi

--- a/base_rpm.one/etc/one-context.d/05-hostname
+++ b/base_rpm.one/etc/one-context.d/05-hostname
@@ -23,7 +23,7 @@ function get_dns_name() {
 }
 
 if [ -n "$SET_HOSTNAME" ]; then
-    set_hostname $SET_HOSTNAME
+    set_hostname $(echo "$SET_HOSTNAME" | sed -e 's/[^-a-zA-Z0-9]/-/g')
 elif [ -n "$DNS_HOSTNAME" ]; then
     set_hostname $(get_dns_name)
 fi

--- a/base_rpm.one/etc/one-context.d/05-hostname
+++ b/base_rpm.one/etc/one-context.d/05-hostname
@@ -23,7 +23,7 @@ function get_dns_name() {
 }
 
 if [ -n "$SET_HOSTNAME" ]; then
-    set_hostname $(echo "$SET_HOSTNAME" | sed -e 's/[^-a-zA-Z0-9]/-/g')
+    set_hostname $(echo "$SET_HOSTNAME" | sed -e 's/[^-a-zA-Z0-9]/-/g' -e 's/^-*//g' -e 's/-*$//g')
 elif [ -n "$DNS_HOSTNAME" ]; then
     set_hostname $(get_dns_name)
 fi


### PR DESCRIPTION
When setting the hostname from `$SET_HOSTNAME`, replace any characters
not allowed in hostnames (as specified in RFC 952) with a hyphen.
This is enables a VM template to safely use the VM's name as the
hostname (by setting the context variable `SET_HOSTNAME=$NAME`).