### PR TITLE
Update 02-ssh_host_key

### DIFF
--- a/base_deb/etc/one-context.d/02-ssh_host_key
+++ b/base_deb/etc/one-context.d/02-ssh_host_key
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ ! -f /etc/ssh/ssh_host_rsa_key ]; then
+if [ ! -s /etc/ssh/ssh_host_rsa_key ]; then
     dpkg-reconfigure openssh-server
 fi
 


### PR DESCRIPTION
also handle zero byte host key files.
had this on ubuntu for reasons i don't understand. (likely caused by this script or ubuntu 14.04's ssh upstart job)
This should ensure it'll go away with another reboot saving some lifes.