### PR TITLE
Modifying file /etc/hostname to set the hostname

### DIFF
--- a/base_rpm.one/etc/one-context.d/15-hostname
+++ b/base_rpm.one/etc/one-context.d/15-hostname
@@ -9,7 +9,8 @@ function set_hostname() {
 
     sed -i '/^HOSTNAME=.*$/d' $CONFIG_FILE
     echo "HOSTNAME=$NAME" >> $CONFIG_FILE
-
+    [[ $(awk -F= '/^VERSION_ID/ {gsub("\"","");print $2}' /etc/os-release) -ge 7 ]] && echo $NAME > /etc/hostname
+        
     hostname $NAME
 }
 


### PR DESCRIPTION
On RHEL and CentOS 7 host name is kept in /etc/hostname, so even if SET_HOSTNAME has a value, the machine was keeping  localhost.localdomain as name. This way the hostname file gets overwritten with contextualization variable value. I'm supposing that file /etc/hostname will be existing in next releases too (OS_VERSION >= 7)