### PR TITLE
Add btrfs to list of FS that growroot will resize.

### DIFF
--- a/base.one/etc/one-context.d/05-grow-rootfs
+++ b/base.one/etc/one-context.d/05-grow-rootfs
@@ -51,4 +51,7 @@ case "${FSTYPE}" in
   xfs)
     xfs_growfs /
     ;;
+  btrfs)
+      btrfs filesystem resize max /
+    ;;
 esac


### PR DESCRIPTION
Add an entry in the growroot script that checks for btrfs and executes a

`btrfs filesystem resize max /`

if `/` is a btrfs filesystem.