### PR TITLE
Abort init script when no context is found

### DIFF
--- a/base/usr/sbin/one-contextd
+++ b/base/usr/sbin/one-contextd
@@ -65,6 +65,10 @@ function get_new_context {
             openssl base64 -d > ${CONTEXT_NEW}
     elif curl -o ${CONTEXT_NEW} http://169.254.169.254/latest/user-data ; then
         echo -n ""
+    else 
+	echo "No context found!!"
+	echo "Exiting...."
+	exit 1
     fi
 }
 


### PR DESCRIPTION
This is a simple change aimed to our current use case: we can have this package installed in a non-opennebula environment.
