### PR TITLE
On Debian always use IPv4 if available, disable IPv6 autoconfiguration

### DIFF
--- a/base_deb.one/etc/one-context.d/10-network
+++ b/base_deb.one/etc/one-context.d/10-network
@@ -155,6 +155,8 @@ gen_iface6_conf() {
 iface $DEV inet6 static
   address $IPV6
   netmask 64
+  autoconf 0
+  accept_ra 0
 EOT
 
     if [ -n "$MTU" ]; then
@@ -213,14 +215,13 @@ EOT
         IPV6=$(get_iface_var "IPV6")
         [[ -z $IPV6 ]] && IPV6=$(get_iface_var "IP6")
         GATEWAY6=$(get_gateway6)
-        CONTEXT_FORCE_IPV4=$(get_iface_var "CONTEXT_FORCE_IPV4")
 
         [ -z "${IP}${IPV6}" ] && continue
         [ -z "${DEV}" ] && continue
 
         echo "auto $DEV"
 
-        [[ -z $IPV6 || -n $CONTEXT_FORCE_IPV4 ]] && gen_iface_conf
+        [[ -n $IP ]] && gen_iface_conf
         [[ -n $IPV6 ]] && gen_iface6_conf
 
     done

--- a/base_rpm.one/etc/one-context.d/10-network
+++ b/base_rpm.one/etc/one-context.d/10-network
@@ -169,7 +169,6 @@ gen_network_configuration()
         IPV6=$(get_iface_var "IPV6")
         [[ -z $IPV6 ]] && IPV6=$(get_iface_var "IP6")
         GATEWAY6=$(get_gateway6)
-        CONTEXT_FORCE_IPV4=$(get_iface_var "CONTEXT_FORCE_IPV4")
 
         [ -z "${IP}${IPV6}" ] && continue
         [ -z "${DEV}" ] && continue


### PR DESCRIPTION
This feature is already present in EL scripts:
b513d94c96ceb0b2efd2a1655fdad4a4f343232c
c2316a74debd9ef0f1633ddbf20584b8c06ad3d3