### PR TITLE
README.md update: fpm 1.6.2 doesn't work anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Other actions include:
 ### Requirements
 
   * Ruby >= 1.8.7
-  * gem fpm
+  * gem fpm >= 1.8.1
   * dpkg utils for deb package creation
   * rpm utils for rpm package creation
 


### PR DESCRIPTION
Fails with "ERROR: Unrecognised option '--output-type'"