### PR TITLE
Please update 05-grow-rootfs##one to work with msdos partitioning and LVM in extended partition

### DIFF
--- a/src/etc/one-context.d/loc-05-grow-rootfs##one
+++ b/src/etc/one-context.d/loc-05-grow-rootfs##one
@@ -28,6 +28,10 @@ if [ "${LVM}" != "no" ]; then
   PARTITION=$(pvdisplay |grep "PV Name"|awk '{print $3}'| sed "s|^${DISK}||")
   PV=$(pvdisplay |grep "PV Name"|awk '{print $3}')
   LV=$(lvdisplay ${DEVICE} |grep "LV Path"|awk '{print $3}')
+  TABLE=$(parted ${DISK} print | grep 'Partition Table:' | awk '{print $3}' | grep 'msdos' | wc -l)
+  if [ ${TABLE} -ne 0 -a ${PARTITION} -gt 4 ]; then 
+    PARTITION="$(parted ${DISK} print | grep 'extended' | awk '{print $1}') $PARTITION"
+  fi
 fi
 
 if [ -n "$DEBUG" ]; then
@@ -37,7 +41,9 @@ if [ -n "$DEBUG" ]; then
   echo PARTITION: ${PARTITION}
 fi
 
-${GROWPART} ${DISK} ${PARTITION}
+for PART in ${PARTITION} ; do
+  ${GROWPART} ${DISK} ${PART}
+done
 
 if [ "${LVM}" != "no" ]; then
   ${PVRESIZE} ${PV}


### PR DESCRIPTION
In Ubuntu 16.04 server default LVM installation with one disc, there is msdos partition table and the PV is in the extended partition. When growing the PV, you must resize the extended partition first and the PV partition second. This change detects the situation and grows both items in msdos (MBR) partition table accordingly.