### PR TITLE
fix: don't override GRUB_CMDLINE_LINUX_DEFAULT

### DIFF
--- a/src/etc/default/grub.d/99-opennebula-settings.cfg##deb.one
+++ b/src/etc/default/grub.d/99-opennebula-settings.cfg##deb.one
@@ -1,2 +1,2 @@
 # Do not configure serial console
-GRUB_CMDLINE_LINUX_DEFAULT="console=tty1"
+GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT console=tty1"


### PR DESCRIPTION
/etc/default/grub.d/99-opennebula-settings.cfg##deb.one overrides GRUB_CMDLINE_LINUX_DEFAULT defined in /etc/default/grub