### PR TITLE
LXD drivers contextualization

### DIFF
--- a/src/etc/one-context.d/loc-10-network##apk.one
+++ b/src/etc/one-context.d/loc-10-network##apk.one
@@ -163,7 +163,7 @@ EOT
 
 get_interface_mac()
 {
-    ip link show | awk '/^[0-9]+: [A-Za-z0-9]+:/ { device=$2; gsub(/:/, "",device)} /link\/ether/ { print device " " $2 }'
+    ip link show | awk '/^[0-9]+: [A-Za-z0-9@]+:/ { device=$2; gsub(/:/, "",device); split(device,dev,"\@")} /link\/ether/ { print dev[1]  " " $2 }'
 }
 
 get_context_interfaces()

--- a/src/etc/one-context.d/loc-10-network##apk.one
+++ b/src/etc/one-context.d/loc-10-network##apk.one
@@ -163,7 +163,7 @@ EOT
 
 get_interface_mac()
 {
-    ip link show | awk '/^[0-9]+: [A-Za-z0-9@]+:/ { device=$2; gsub(/:/, "",device); split(device,dev,"\@")} /link\/ether/ { print dev[1]  " " $2 }'
+    ip link show | awk '/^[0-9]+: [A-Za-z0-9@]+:/ { device=$2; gsub(/:/, "",device); split(device,dev,"@")} /link\/ether/ { print dev[1]  " " $2 }'
 }
 
 get_context_interfaces()

--- a/src/etc/one-context.d/loc-10-network##arch.one
+++ b/src/etc/one-context.d/loc-10-network##arch.one
@@ -198,7 +198,7 @@ EOT
 
 get_interface_mac()
 {
-    ip link show | awk '/^[0-9]+: [A-Za-z0-9@]+:/ { device=$2; gsub(/:/, "",device); split(device,dev,"\@")} /link\/ether/ { print dev[1]  " " $2 }'
+    ip link show | awk '/^[0-9]+: [A-Za-z0-9@]+:/ { device=$2; gsub(/:/, "",device); split(device,dev,"@")} /link\/ether/ { print dev[1]  " " $2 }'
 }
 
 get_context_interfaces()

--- a/src/etc/one-context.d/loc-10-network##arch.one
+++ b/src/etc/one-context.d/loc-10-network##arch.one
@@ -198,7 +198,7 @@ EOT
 
 get_interface_mac()
 {
-    ip link show | awk '/^[0-9]+: [[:alnum:]]+:/ { device=$2; gsub(/:/, "",device)} /link\/ether/ { print device " " $2 }'
+    ip link show | awk '/^[0-9]+: [A-Za-z0-9@]+:/ { device=$2; gsub(/:/, "",device); split(device,dev,"\@")} /link\/ether/ { print dev[1]  " " $2 }'
 }
 
 get_context_interfaces()

--- a/src/etc/one-context.d/loc-10-network##deb.one
+++ b/src/etc/one-context.d/loc-10-network##deb.one
@@ -190,7 +190,7 @@ EOT
 
 get_interface_mac()
 {
-    ip link show | awk '/^[0-9]+: [A-Za-z0-9]+:/ { device=$2; gsub(/:/, "",device)} /link\/ether/ { print device " " $2 }'
+    ip link show | awk '/^[0-9]+: [A-Za-z0-9@]+:/ { device=$2; gsub(/:/, "",device); split(device,dev,"\@")} /link\/ether/ { print dev[1]  " " $2 }'
 }
 
 get_context_interfaces()

--- a/src/etc/one-context.d/loc-10-network##deb.one
+++ b/src/etc/one-context.d/loc-10-network##deb.one
@@ -190,7 +190,7 @@ EOT
 
 get_interface_mac()
 {
-    ip link show | awk '/^[0-9]+: [A-Za-z0-9@]+:/ { device=$2; gsub(/:/, "",device); split(device,dev,"\@")} /link\/ether/ { print dev[1]  " " $2 }'
+    ip link show | awk '/^[0-9]+: [A-Za-z0-9@]+:/ { device=$2; gsub(/:/, "",device); split(device,dev,"@")} /link\/ether/ { print dev[1]  " " $2 }'
 }
 
 get_context_interfaces()

--- a/src/etc/one-context.d/loc-10-network##rpm.one
+++ b/src/etc/one-context.d/loc-10-network##rpm.one
@@ -156,7 +156,7 @@ EOT
 
 get_interface_mac()
 {
-    ip link show | awk '/^[0-9]+: [A-Za-z0-9@]+:/ { device=$2; gsub(/:/, "",device); split(device,dev,"\@")} /link\/ether/ { print dev[1]  " " $2 }'
+    ip link show | awk '/^[0-9]+: [A-Za-z0-9@]+:/ { device=$2; gsub(/:/, "",device); split(device,dev,"@")} /link\/ether/ { print dev[1]  " " $2 }'
 }
 
 get_context_interfaces()

--- a/src/etc/one-context.d/loc-10-network##rpm.one
+++ b/src/etc/one-context.d/loc-10-network##rpm.one
@@ -156,7 +156,7 @@ EOT
 
 get_interface_mac()
 {
-    ip link show | awk '/^[0-9]+: [[:alnum:]]+:/ { device=$2; gsub(/:/, "",device)} /link\/ether/ { print device " " $2 }'
+    ip link show | awk '/^[0-9]+: [A-Za-z0-9@]+:/ { device=$2; gsub(/:/, "",device); split(device,dev,"\@")} /link\/ether/ { print dev[1]  " " $2 }'
 }
 
 get_context_interfaces()

--- a/src/usr/sbin/one-contextd
+++ b/src/usr/sbin/one-contextd
@@ -166,6 +166,9 @@ function get_new_context {
             cp "${fn_mnt_context}" "${CONTEXT_NEW}"
         fi
 
+    elif [ -f /mnt/context.sh ]; then
+        cp /mnt/context.sh ${CONTEXT_NEW}
+    
     elif vmware_context ; then
         log debug "Reading context via vmtoolsd"
         vmtoolsd --cmd 'info-get guestinfo.opennebula.context' | \

--- a/src/usr/sbin/one-contextd
+++ b/src/usr/sbin/one-contextd
@@ -257,7 +257,8 @@ function cleanup {
     # unmount context
     if [ -d "${MOUNT_DIR}" ]; then
         log debug "Unmounting ${MOUNT_DIR}"
-        umount -l "${MOUNT_DIR}" || rm -r "${MOUNT_DIR}"
+        umount -l "${MOUNT_DIR}"
+        rm -r "${MOUNT_DIR}"
     fi
 
     # remove remporary files

--- a/src/usr/sbin/one-contextd
+++ b/src/usr/sbin/one-contextd
@@ -162,8 +162,9 @@ function get_new_context {
 
         context-sh $MOUNT_DIR
 
-    elif find '/tmp/context' -mindepth 1 -print -quit 2>/dev/null | grep -q .; then
-        context-sh '/tmp/context'
+    elif find '/context' -mindepth 1 -print -quit 2>/dev/null | grep -q .; then
+        MOUNT_DIR=/context 
+        context-sh $MOUNT_DIR
 
 
     elif vmware_context ; then

--- a/src/usr/sbin/one-contextd
+++ b/src/usr/sbin/one-contextd
@@ -257,8 +257,7 @@ function cleanup {
     # unmount context
     if [ -d "${MOUNT_DIR}" ]; then
         log debug "Unmounting ${MOUNT_DIR}"
-        umount -l "${MOUNT_DIR}"
-        rm -r "${MOUNT_DIR}"
+        umount -l "${MOUNT_DIR}" || rm -r "${MOUNT_DIR}/*"
     fi
 
     # remove remporary files

--- a/src/usr/sbin/one-contextd
+++ b/src/usr/sbin/one-contextd
@@ -160,15 +160,12 @@ function get_new_context {
             exit 1
         fi
 
-        local fn_mnt_context="${MOUNT_DIR}/context.sh"
-        if [ -f "${fn_mnt_context}" ]; then
-            log debug "Found context ${fn_mnt_context}"
-            cp "${fn_mnt_context}" "${CONTEXT_NEW}"
-        fi
+        context-sh $MOUNT_DIR
 
-    elif [ -f /mnt/context.sh ]; then
-        cp /mnt/context.sh ${CONTEXT_NEW}
-    
+    elif find '/tmp/context' -mindepth 1 -print -quit 2>/dev/null | grep -q .; then
+        context-sh '/tmp/context'
+
+
     elif vmware_context ; then
         log debug "Reading context via vmtoolsd"
         vmtoolsd --cmd 'info-get guestinfo.opennebula.context' | \
@@ -184,6 +181,14 @@ function get_new_context {
         log err 'Error: No contextualization found' 2
         exit 1
     fi
+}
+
+function context-sh {
+    local fn_mnt_context="${1}/context.sh"
+        if [ -f "${fn_mnt_context}" ]; then
+            log debug "Found context ${fn_mnt_context}"
+            cp "${fn_mnt_context}" "${CONTEXT_NEW}"
+        fi
 }
 
 function check_context {

--- a/src/usr/sbin/one-contextd
+++ b/src/usr/sbin/one-contextd
@@ -160,12 +160,12 @@ function get_new_context {
             exit 1
         fi
 
-        context-sh $MOUNT_DIR
+        context_sh $MOUNT_DIR
 
     elif find '/context' -mindepth 1 -print -quit 2>/dev/null | grep -q .; then
         mount_dir
-        cp '/context/context.sh' "${MOUNT_DIR}"
-        context-sh "${MOUNT_DIR}"
+        cp '/context/*' "${MOUNT_DIR}"
+        context_sh "${MOUNT_DIR}"
 
 
 
@@ -191,12 +191,12 @@ function mount_dir
     MOUNT_DIR=$(mktemp -d "${RUNTIME_DIR}/mount.XXXXXX" 2>/dev/null)
 }
 
-function context-sh {
+function context_sh {
     local fn_mnt_context="${1}/context.sh"
-        if [ -f "${fn_mnt_context}" ]; then
-            log debug "Found context ${fn_mnt_context}"
-            cp "${fn_mnt_context}" "${CONTEXT_NEW}"
-        fi
+    if [ -f "${fn_mnt_context}" ]; then
+        log debug "Found context ${fn_mnt_context}"
+        cp "${fn_mnt_context}" "${CONTEXT_NEW}"
+    fi
 }
 
 function check_context {
@@ -257,7 +257,7 @@ function cleanup {
     # unmount context
     if [ -d "${MOUNT_DIR}" ]; then
         log debug "Unmounting ${MOUNT_DIR}"
-        umount -l "${MOUNT_DIR}" || rm -r "${MOUNT_DIR}/*"
+        umount -l "${MOUNT_DIR}" || rm -r "${MOUNT_DIR}"
     fi
 
     # remove remporary files

--- a/src/usr/sbin/one-contextd
+++ b/src/usr/sbin/one-contextd
@@ -147,7 +147,7 @@ function vmware_context {
 function get_new_context {
     local dev_context=$(blkid -l -t LABEL="CONTEXT" -o device)
     if [ -e "${dev_context}" ]; then
-        MOUNT_DIR=$(mktemp -d "${RUNTIME_DIR}/mount.XXXXXX" 2>/dev/null)
+        mount_dir
         if ! [ -d "${MOUNT_DIR}" ]; then
             log err 'Error: Failed to create mountpoint' 2
             exit 1
@@ -163,8 +163,10 @@ function get_new_context {
         context-sh $MOUNT_DIR
 
     elif find '/context' -mindepth 1 -print -quit 2>/dev/null | grep -q .; then
-        MOUNT_DIR=/context 
-        context-sh $MOUNT_DIR
+        mount_dir
+        cp '/context/context.sh' "${MOUNT_DIR}"
+        context-sh "${MOUNT_DIR}"
+
 
 
     elif vmware_context ; then
@@ -182,6 +184,11 @@ function get_new_context {
         log err 'Error: No contextualization found' 2
         exit 1
     fi
+}
+
+function mount_dir
+{
+    MOUNT_DIR=$(mktemp -d "${RUNTIME_DIR}/mount.XXXXXX" 2>/dev/null)
 }
 
 function context-sh {
@@ -251,7 +258,7 @@ function cleanup {
     if [ -d "${MOUNT_DIR}" ]; then
         log debug "Unmounting ${MOUNT_DIR}"
         umount -l "${MOUNT_DIR}"
-        rmdir "${MOUNT_DIR}"
+        rm -r "${MOUNT_DIR}"
     fi
 
     # remove remporary files


### PR DESCRIPTION
Some modifications were required to the context package
- interface name parsing due to the network name-spacing introducing `@` in the ip command output
- handling not existing ISO mounts in container. Context ISO is mounted on the host and passed trough to the container

The contextualization shouldn't interfere with KVM