### PR TITLE
Fix FreeBSD's 'echo' lack of -e option and 'base64' utility

### DIFF
--- a/src/etc/one-context.d/net-97-start-script
+++ b/src/etc/one-context.d/net-97-start-script
@@ -8,10 +8,10 @@ START_SCRIPT_AVAILABLE=no
 chmod 700 "${TMP_DIR}"
 
 if [ -n "$START_SCRIPT_BASE64" ]; then
-    echo -en "$START_SCRIPT_BASE64" | base64 -d > $TMP_FILE
+    printf '%s\r' "$START_SCRIPT_BASE64" | openssl enc -d -base64 -A > $TMP_FILE
     START_SCRIPT_AVAILABLE=yes
 elif [ -n "$START_SCRIPT" ]; then
-    echo -en "$START_SCRIPT" > $TMP_FILE
+    printf '%s\r' "$START_SCRIPT" > $TMP_FILE
     START_SCRIPT_AVAILABLE=yes
 fi
 


### PR DESCRIPTION
- FreeBSD's 'echo' does not happen to have -e option - this caused the `START_SCRIPT_BASE64` decoding step to result in an empty '`one-start-script`'. And therefore it's replaced with the `printf` builtin (see ref. https://stackoverflow.com/a/10576796/2172072)

```sh
[root@freebsd]/root: echo -en "VGhpcyBpcyBiYXNlNjQ="
-en VGhpcyBpcyBiYXNlNjQ=
```

- Also, in FreeBSD 9.3 'base64' was removed from the default installation; this reverts https://github.com/OpenNebula/addon-context-linux/commit/16d375d6eaf3bab74835c217ce8347c5a316b4dd

```sh
[root@freebsd]/root: freebsd-version
11.1-RELEASE-p4
[root@freebsd]/root: base64
base64: Command not found.
```

- This can be considered part of https://github.com/OpenNebula/addon-context-linux/issues/131 - cc/ @vholer 