### PR TITLE
B #138 run contextualization only from CDROM

### DIFF
--- a/src/lib/udev/rules.d/65-context.rules##rpm.systemd.one
+++ b/src/lib/udev/rules.d/65-context.rules##rpm.systemd.one
@@ -6,6 +6,7 @@ SUBSYSTEM=="net", ACTION=="add", \
 # every second event and triggers systemd service one-context-reconfigure.
 # This service also stops any existing delayed reconfiguration.
 SUBSYSTEM=="block", ACTION=="change", \
+  ENV{ID_CDROM}=="1", \
   ENV{ID_FS_TYPE}=="iso9660" ENV{ID_FS_LABEL_ENC}=="CONTEXT", \
   ENV{SEQNUM}=="*[02468]", \
   RUN+="/bin/systemctl --no-block start one-context-reconfigure.service"


### PR DESCRIPTION
device that has `ID_CDROM=1` set in the udev environment.

This will prevent re-contextualization of the host in case when an VM is LXD or KVM host (nested virtualization)