### PR TITLE
F #115: loc-05-grow-rootfs can be disabled by context

### DIFF
--- a/src/etc/one-context.d/loc-05-grow-rootfs
+++ b/src/etc/one-context.d/loc-05-grow-rootfs
@@ -2,6 +2,12 @@
 
 set -e
 
+if [ "${GROW_ROOT_FS,,}" = 'false'  ]
+then
+    echo "growing root filesystem is disabled by context GROW_ROOT_FS=false"
+    exit 0
+fi
+
 # FreeBSD
 if [ -x /etc/rc.d/growfs ]; then
     /etc/rc.d/growfs onestart


### PR DESCRIPTION
We want to disable the “loc-05-grow-rootfs” for custom partitionning
provided by our orchestrator.

Changes proposed in this pull request:

* src/etc/one-context.d/loc-05-grow-rootfs: exit if the context
  variable “GROW_ROOT_FS” is “false”.