### PR TITLE
B #118: one-context-force breaks boot status

### DIFF
--- a/src/usr/lib/systemd/system/one-context-force.service##systemd.one
+++ b/src/usr/lib/systemd/system/one-context-force.service##systemd.one
@@ -2,6 +2,8 @@
 Description=OpenNebula forced reconfiguration
 After=one-context.service
 Requisite=one-context.service
+ConditionPathExists=/var/run/one-context/context.sh.local
+ConditionPathExists=/var/run/one-context/context.sh.network
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
We must make sure "one-context-force.service" is not run during boot disk
detection but on hotplug events.

When booting with a swap partition on the disk, the udev rules will
start the "one-context-force" service long before "one-context-local"
and "one-context".

This results in the system being in "degraded" state as reported by
"systemctl is-system-running".

Changes proposed in this pull request:

* src/usr/lib/systemd/system/one-context-force.service##systemd.one:
  add conditions to run only on hotplug events.