### PR TITLE
fixed get_network to calculate correctly the network address

### DIFF
--- a/src/etc/one-context.d/loc-10-network##apk.one
+++ b/src/etc/one-context.d/loc-10-network##apk.one
@@ -41,7 +41,9 @@ get_network() {
     network=$(get_iface_var "NETWORK")
 
     if [ -z "$network" ]; then
-        network="$(echo $IP | cut -d'.' -f1,2,3).0"
+        IFS=. read -r i1 i2 i3 i4 <<< "$IP"
+        IFS=. read -r m1 m2 m3 m4 <<< "$(get_mask)"
+        network=$(printf "%d.%d.%d.%d\n" "$((i1 & m1))" "$((i2 & m2))" "$((i3 & m3))" "$((i4 & m4))")
     fi
 
     echo $network

--- a/src/etc/one-context.d/loc-10-network##arch.one
+++ b/src/etc/one-context.d/loc-10-network##arch.one
@@ -56,7 +56,9 @@ get_network() {
     network=$(get_iface_var "NETWORK")
 
     if [ -z "$network" ]; then
-        network="$(echo $IP | cut -d'.' -f1,2,3).0"
+        IFS=. read -r i1 i2 i3 i4 <<< "$IP"
+        IFS=. read -r m1 m2 m3 m4 <<< "$(get_mask)"
+        network=$(printf "%d.%d.%d.%d\n" "$((i1 & m1))" "$((i2 & m2))" "$((i3 & m3))" "$((i4 & m4))")
     fi
 
     echo $network

--- a/src/etc/one-context.d/loc-10-network##bsd.one
+++ b/src/etc/one-context.d/loc-10-network##bsd.one
@@ -37,7 +37,9 @@ get_network() {
     network=$(get_iface_var "NETWORK")
 
     if [ -z "$network" ]; then
-        network="$(echo $IP | cut -d'.' -f1,2,3).0"
+        IFS=. read -r i1 i2 i3 i4 <<< "$IP"
+        IFS=. read -r m1 m2 m3 m4 <<< "$(get_mask)"
+        network=$(printf "%d.%d.%d.%d\n" "$((i1 & m1))" "$((i2 & m2))" "$((i3 & m3))" "$((i4 & m4))")
     fi
 
     echo $network

--- a/src/etc/one-context.d/loc-10-network##deb.one
+++ b/src/etc/one-context.d/loc-10-network##deb.one
@@ -37,7 +37,9 @@ get_network() {
     network=$(get_iface_var "NETWORK")
 
     if [ -z "$network" ]; then
-        network="$(echo $IP | cut -d'.' -f1,2,3).0"
+        IFS=. read -r i1 i2 i3 i4 <<< "$IP"
+        IFS=. read -r m1 m2 m3 m4 <<< "$(get_mask)"
+        network=$(printf "%d.%d.%d.%d\n" "$((i1 & m1))" "$((i2 & m2))" "$((i3 & m3))" "$((i4 & m4))")
     fi
 
     echo $network

--- a/src/etc/one-context.d/loc-10-network##rpm.one
+++ b/src/etc/one-context.d/loc-10-network##rpm.one
@@ -37,7 +37,9 @@ get_network() {
     network=$(get_iface_var "NETWORK")
 
     if [ -z "$network" ]; then
-        network="$(echo $IP | cut -d'.' -f1,2,3).0"
+        IFS=. read -r i1 i2 i3 i4 <<< "$IP"
+        IFS=. read -r m1 m2 m3 m4 <<< "$(get_mask)"
+        network=$(printf "%d.%d.%d.%d\n" "$((i1 & m1))" "$((i2 & m2))" "$((i3 & m3))" "$((i4 & m4))")
     fi
 
     echo $network


### PR DESCRIPTION
<!--//////////////////////////////////////////////////////////-->
<!-- Please note the pull request can be merged only if all   -->
<!-- commits are properly signed! Read the instructions here: -->
<!-- https://github.com/OpenNebula/one/wiki/Sign-Your-Work    -->
<!--//////////////////////////////////////////////////////////-->

Changes proposed in this pull request:
- fixed function get_network in loc-10-network## files to calculate correctly the network address. Until now if not network address specified in the context, it was just taking the first three octets from the IP and was assuming that the network is /24.
-
-
