### PR TITLE
debian: add ifupdown2 support

### DIFF
--- a/src/etc/one-context.d/loc-10-network##deb.one
+++ b/src/etc/one-context.d/loc-10-network##deb.one
@@ -289,6 +289,11 @@ configure_network()
 
 deactivate_network()
 {
+
+    if test -f "/usr/sbin/ifreload"; then
+        return
+    fi
+
     IFACES=`/sbin/ifquery --list -a`
 
     for i in $IFACES; do
@@ -301,6 +306,12 @@ deactivate_network()
 
 activate_network()
 {
+
+    if test -f "/usr/sbin/ifreload"; then
+        /usr/sbin/ifreload -a
+        return
+    fi
+
     IFACES=`/sbin/ifquery --list -a`
 
     for i in $IFACES; do

--- a/targets.sh
+++ b/targets.sh
@@ -176,7 +176,7 @@ case "${TARGET}" in
         RELSUFFIX=${RELSUFFIX:-}
         TYPE=${TYPE:-deb}
         TAGS=${TAGS:-deb sysv systemd upstart one}
-        DEPENDS=${DEPENDS:-util-linux bash curl bind9-host cloud-utils parted ruby ifupdown acpid sudo passwd dbus openssh-server open-vm-tools qemu-guest-agent}
+        DEPENDS=${DEPENDS:-util-linux bash curl bind9-host cloud-utils parted ruby ifupdown|ifupdown2 acpid sudo passwd dbus openssh-server open-vm-tools qemu-guest-agent}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-cloud-init}
         CONFLICTS=${CONFLICTS:-${REPLACES} one-context-ec2}
@@ -191,7 +191,7 @@ case "${TARGET}" in
         RELSUFFIX=${RELSUFFIX:-}
         TYPE=${TYPE:-deb}
         TAGS=${TAGS:-deb sysv systemd upstart ec2}
-        DEPENDS=${DEPENDS:-util-linux bash curl bind9-host cloud-utils parted ruby ifupdown sudo passwd dbus openssh-server resolvconf}
+        DEPENDS=${DEPENDS:-util-linux bash curl bind9-host cloud-utils parted ruby ifupdown|ifupdown2 sudo passwd dbus openssh-server resolvconf}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-cloud-init}
         CONFLICTS=${CONFLICTS:-${REPLACES} one-context}


### PR DESCRIPTION
ifupdown2 is an alternative to classic ifupdown
https://github.com/CumulusNetworks/ifupdown2

It's allow to reload online network configuration with dependencies
and 100% compatible with classic ifupdown1 config.

Signed-off-by: Alexandre Derumier <aderumier@odiso.com>

