### PR TITLE
B #112: Move script location outside of /tmp

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -174,6 +174,10 @@ else
         cat ${POSTUP} >"${_POSTUP}"
     fi
 
+    # set the package version of onesysprep
+    sed -i "s/\<_PACKAGE_VERSION_\>/${VERSION}-${RELEASE_FULL}/" \
+        "${BUILD_DIR}/usr/sbin/onesysprep"
+
     fpm --name "${NAME}" --version "${VERSION}" --iteration "${RELEASE_FULL}" \
         --architecture all --license "${LICENSE}" \
         --vendor "${VENDOR}" --maintainer "${MAINTAINER}" \

--- a/src/etc/one-context.d/net-97-start-script
+++ b/src/etc/one-context.d/net-97-start-script
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # -------------------------------------------------------------------------- #
-# Copyright 2002-2020, OpenNebula Project, OpenNebula Systems                #
+# Copyright 2002-2021, OpenNebula Project, OpenNebula Systems                #
 #                                                                            #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may    #
 # not use this file except in compliance with the License. You may obtain    #
@@ -16,25 +16,33 @@
 # limitations under the License.                                             #
 #--------------------------------------------------------------------------- #
 
+set -e
+
 MOUNT_DIR=${MOUNT_DIR:-/mnt}
-TMP_DIR=$(mktemp -d "/tmp/one-context.XXXXXX")
-TMP_FILE="${TMP_DIR}/one-start-script"
+TMP_DIR=$(mktemp -d "${TMP_DIR:-/var/lib/one-context/tmp}/one-context.XXXXXX")
 START_SCRIPT_AVAILABLE=no
 
-chmod 700 "${TMP_DIR}"
+TMP_FILE="${TMP_DIR}/one-start-script"
 
-if [ -n "$START_SCRIPT_BASE64" ]; then
-    echo "${START_SCRIPT_BASE64}" | base64 -d > $TMP_FILE
+cleanup()
+{
+    rm -rf "${TMP_DIR}"
+}
+
+trap cleanup EXIT
+
+chmod 0700 "${TMP_DIR}"
+
+if [ -n "${START_SCRIPT_BASE64}" ]; then
+    echo "${START_SCRIPT_BASE64}" | base64 -d > "${TMP_FILE}"
     START_SCRIPT_AVAILABLE=yes
-elif [ -n "$START_SCRIPT" ]; then
-    echo "${START_SCRIPT}" > $TMP_FILE
+elif [ -n "${START_SCRIPT}" ]; then
+    echo "${START_SCRIPT}" > "${TMP_FILE}"
     START_SCRIPT_AVAILABLE=yes
 fi
 
-if [ "$START_SCRIPT_AVAILABLE" = "yes" ]; then
-    cd $MOUNT_DIR
-    chmod +x $TMP_FILE
-    $TMP_FILE
+if [ "${START_SCRIPT_AVAILABLE}" = "yes" ]; then
+    cd "${MOUNT_DIR}"
+    chmod +x "${TMP_FILE}"
+    "${TMP_FILE}"
 fi
-
-rm -rf "${TMP_DIR}"

--- a/src/etc/one-context.d/net-98-execute-scripts
+++ b/src/etc/one-context.d/net-98-execute-scripts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # -------------------------------------------------------------------------- #
-# Copyright 2002-2020, OpenNebula Project, OpenNebula Systems                #
+# Copyright 2002-2021, OpenNebula Project, OpenNebula Systems                #
 #                                                                            #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may    #
 # not use this file except in compliance with the License. You may obtain    #
@@ -16,23 +16,33 @@
 # limitations under the License.                                             #
 #--------------------------------------------------------------------------- #
 
-MOUNT_DIR=${MOUNT_DIR:-/mnt}
-TMP_DIR=$(mktemp -d "/tmp/one-context.XXXXXX")
+set -e
 
-chmod 700 "${TMP_DIR}"
+MOUNT_DIR="${MOUNT_DIR:-/mnt}"
+TMP_DIR=$(mktemp -d "${TMP_DIR:-/var/lib/one-context/tmp}/one-context.XXXXXX")
 
-if [ -z "$INIT_SCRIPTS" ]; then
-    if [ -f "$MOUNT_DIR/init.sh" ]; then
+cleanup()
+{
+    rm -rf "${TMP_DIR}"
+}
+
+trap cleanup EXIT
+
+chmod 0700 "${TMP_DIR}"
+
+if [ -z "${INIT_SCRIPTS}" ]; then
+    if [ -f "${MOUNT_DIR}/init.sh" ]; then
         INIT_SCRIPTS=init.sh
     fi
 fi
 
-cd $MOUNT_DIR
+cd "${MOUNT_DIR}"
 
+_result=0
 for f in $INIT_SCRIPTS; do
-    cp "$f" "${TMP_DIR}/"
-    chmod +x $TMP_DIR/$f
-    $TMP_DIR/$f
+    cp "${f}" "${TMP_DIR}/"
+    chmod +x "${TMP_DIR}/${f}"
+    "${TMP_DIR}/${f}" || _result=$?
 done
 
-rm -rf "${TMP_DIR}"
+exit $_result

--- a/src/usr/sbin/one-contextd
+++ b/src/usr/sbin/one-contextd
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # -------------------------------------------------------------------------- #
-# Copyright 2002-2020, OpenNebula Project, OpenNebula Systems                #
+# Copyright 2002-2021, OpenNebula Project, OpenNebula Systems                #
 #                                                                            #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may    #
 # not use this file except in compliance with the License. You may obtain    #
@@ -21,13 +21,15 @@ set -e
 TYPE="${1:-all}"  # local, network, all
 COMMAND="${2}"    # reconfigure?
 
-SCRIPTS_DIR=${SCRIPTS_DIR:-/etc/one-context.d}
-RUNTIME_DIR=${RUNTIME_DIR:-/var/run/one-context}
+SCRIPTS_DIR="${SCRIPTS_DIR:-/etc/one-context.d}"
+RUNTIME_DIR="${RUNTIME_DIR:-/var/run/one-context}"
+TMP_DIR="${TMP_DIR:-/var/lib/one-context/tmp}"
 LOCK_FILE="${RUNTIME_DIR}/one-context.lock"
 CONTEXT_BASE="${RUNTIME_DIR}/context.sh"
 SYSLOG_TAG="$(basename $0)"
 
 [ -d "${RUNTIME_DIR}" ] || mkdir -m 0700 -p "${RUNTIME_DIR}"
+[ -d "${TMP_DIR}" ] || mkdir -m 0700 -p "${TMP_DIR}"
 CONTEXT_NEW=$(mktemp "${CONTEXT_BASE}.XXXXXX" 2>/dev/null)
 SYSLOG_FACILITY="${SYSLOG_FACILITY:-local3}"
 

--- a/src/usr/sbin/onesysprep
+++ b/src/usr/sbin/onesysprep
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # ---------------------------------------------------------------------------- #
-# Copyright 2020, OpenNebula Project, OpenNebula Systems                       #
+# Copyright 2020-2021, OpenNebula Project, OpenNebula Systems                  #
 #                                                                              #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may      #
 # not use this file except in compliance with the License. You may obtain      #
@@ -33,7 +33,6 @@ set -e
 
 CMD=$(basename "$0")
 CMDLINE="${0} ${*}"
-VERSION='5.13.80'
 
 # here are declared all sysprep operations - keep the following format:
 #   <operation>:<default>:<comment>
@@ -80,6 +79,7 @@ udev-persistent-net     :1: Remove udev persistent net rules
 user-account            :0: Remove the user accounts in the guest
 utmp                    :1: Remove the utmp file
 yum-uuid                :1: Remove the yum UUID
+one-cleanup             :1: Remove OpenNebula-owned working directories
 one-shell-history       :1: Remove the .history file
 one-hostname            :1: Remove hostname and fix hosts file
 one-resolvconf          :1: Remove nameservers
@@ -1744,6 +1744,15 @@ op_yum_uuid()
 
 # extra one operations
 
+op_one_cleanup()
+(
+    run_op() { echo "+ ${*}" ; "$@" ; }
+
+    run_op rm -vrf \
+        /var/lib/one-context/ \
+        ;
+)
+
 op_one_shell_history()
 (
     run_op() { echo "+ ${*}" ; "$@" ; }
@@ -2046,8 +2055,8 @@ fi
 cat <<EOF
    ___   _ __    ___
   / _ \ | '_ \  / _ \   OpenNebula System Preparation Tool
- | (_) || | | ||  __/   (c) 2002-2020, OpenNebula Project, OpenNebula Systems
-  \___/ |_| |_| \___|   Version ${VERSION}
+ | (_) || | | ||  __/   (c) 2002-2021, OpenNebula Project, OpenNebula Systems
+  \___/ |_| |_| \___|   Version _PACKAGE_VERSION_
 
 EOF
 


### PR DESCRIPTION
Introduce new OpenNebula directory /var/lib/one-context where a new tmp
directory is located. This new one will not be mounted with noexec
option on any system by default.

Add cleanup handler on the script exit and ensure the correct return
code for the init scripts (if one or more fail then return non-zero).

Update onesysprep and set its version by generate.sh script.

Signed-off-by: Petr Ospalý <pospaly@opennebula.io>

<!--//////////////////////////////////////////////////////////-->
<!-- Please note the pull request can be merged only if all   -->
<!-- commits are properly signed! Read the instructions here: -->
<!-- https://github.com/OpenNebula/one/wiki/Sign-Your-Work    -->
<!--//////////////////////////////////////////////////////////-->
