### PR TITLE
Fix some errors in FreeBSD 13

### DIFF
--- a/src/usr/sbin/one-contextd
+++ b/src/usr/sbin/one-contextd
@@ -156,7 +156,7 @@ function get_new_context {
                 blkid | grep "LABEL=['\"]CONTEXT['\"]" | cut -d: -f1;
             } | grep -v '^/dev/loop' | head -n1
         )
-    elif [[ "$distro" == "BSD" ]]; then
+    elif [[ "$distro" == "BSD" ]] && [[ $(glabel status | grep CONTEXT) ]]; then
         local dev_context="/dev/"$(glabel status | grep CONTEXT | awk '{print $3}')
     fi
 
@@ -290,7 +290,7 @@ function acquire_lock {
 
 function cleanup {
     # unmount context
-    if [ -d "${MOUNT_DIR}" ]; then
+    if [ -d "${MOUNT_DIR}" ] && [ -n "$(mount | grep ${MOUNT_DIR})" ]; then
         log debug "Unmounting ${MOUNT_DIR}"
         if [[ "$distro" == "Linux" ]]; then
 	    umount -l "${MOUNT_DIR}"


### PR DESCRIPTION
- In case the CD-ROM is not mounted "glabel status | grep CONTEXT | awk '{print $3}'"
  will have a null string which will eventually assign the value "/dev/" to "dev_context"
  variable. In later occasions while existence of "dev_context" is checked it will
  always return true and no elif conditions will be executed. Add additional glabel check
  for BSD.
- In case the CD-ROM is not mounted and used there is nothing to unmount and eventually
  trying to unmount will throw error. So add an additional check to see if "MOUNT_DIR" is
  used as any mount points or not.

<!--//////////////////////////////////////////////////////////-->
<!-- Please note the pull request can be merged only if all   -->
<!-- commits are properly signed! Read the instructions here: -->
<!-- https://github.com/OpenNebula/one/wiki/Sign-Your-Work    -->
<!--//////////////////////////////////////////////////////////-->

Changes proposed in this pull request:
- briefly describe change here,
- briefly describe change here,
- briefly describe change here.
