### PR TITLE
B #231: Workaround the mawk issue on Debian

### DIFF
--- a/src/usr/sbin/onesysprep
+++ b/src/usr/sbin/onesysprep
@@ -291,6 +291,23 @@ run_cmd()
     fi
 }
 
+# trivial test of awk command capabilities and compliance - it will output
+# either YES or NO
+is_awk_correct()
+(
+    _awk_result=$(echo 'abcABC   xyz123.' | awk '
+        {
+            sub(/[[:upper:]]+[[:space:]]+[[:alnum:]]+/, "");
+            print;
+        }')
+
+    if [ "${_awk_result}" = 'abc.' ] ; then
+        echo 'YES'
+    else
+        echo 'NO'
+    fi
+)
+
 # arg: [normal|summary]
 # if used with argument 'summary' then it will print out summary of supported
 # operations - otherwise it will output parseable: <op>:<default>
@@ -306,16 +323,16 @@ parse_sysprep_operations()
             next;
 
         op = $1;
-        sub(/^[[:space:]]*/, "", op);
-        sub(/[[:space:]]*$/, "", op);
+        sub(/^[ ]*/, "", op);
+        sub(/[ ]*$/, "", op);
 
         default_op = $2;
-        sub(/^[[:space:]]*/, "", default_op);
-        sub(/[[:space:]]*$/, "", default_op);
+        sub(/^[ ]*/, "", default_op);
+        sub(/[ ]*$/, "", default_op);
 
         comment = $3;
-        sub(/^[[:space:]]*/, "", comment);
-        sub(/[[:space:]]*$/, "", comment);
+        sub(/^[ ]*/, "", comment);
+        sub(/[ ]*$/, "", comment);
 
         count++;
         ops[count] = op;
@@ -451,6 +468,19 @@ get_operations()
             ;;
     esac
 )
+
+sanity_check()
+{
+    # test the sanity of an awk implementation
+    _ONE_VALID_AWK=$(is_awk_correct)
+    export _ONE_VALID_AWK
+
+    if [ "${_ONE_VALID_AWK}" = 'NO' ] ; then
+        warn "The currently used awk command does not support POSIX:"
+        printf "\n%s\n\n" "$(awk -W version 2>&1 || true)"
+        printf "[!] NOTE: Install an alternative (e.g. gawk) or some operations may be skipped!\n\n"
+    fi
+}
 
 # this will try to guess the system it is running on and if it is supported by
 # this script
@@ -661,6 +691,7 @@ parse_password_arguments()
 }
 
 # arg: <length>
+# shellcheck disable=SC2120
 gen_password()
 {
     pw_length="${1:-16}"
@@ -671,15 +702,17 @@ gen_password()
             new_pw=$(pwgen -s "${pw_length}" 1)
             break
         elif command -v openssl >/dev/null ; then
+            # shellcheck disable=SC2086
             new_pw="${new_pw}$(openssl rand -base64 ${pw_length} | tr -dc '[:alnum:]')"
         else
             new_pw="${new_pw}$(head /dev/urandom | tr -dc '[:alnum:]')"
         fi
         # shellcheck disable=SC2000
+        # shellcheck disable=SC2086
         [ "$(echo $new_pw | wc -c)" -ge "$pw_length" ] && break
     done
 
-    echo "$new_pw" | cut -c1-${pw_length}
+    echo "$new_pw" | cut -c1-"${pw_length}"
 }
 
 # arg: <user:locked:disabled:file:password:random:value...>
@@ -963,17 +996,34 @@ run_ops()
                 "Run operation"
             printf " ${SETCOLOR_ON_COMMAND}%s${SETCOLOR_OFF}\n" \
                 "${_op}"
+
+            # if-wrap
             if eval "op_${_op_func}" ; then
-                printf "${SETCOLOR_ON_HIGHLIGHT}%s${SETCOLOR_OFF}" \
-                    "Result"
-                printf " ... ${SETCOLOR_ON_OK}%s${SETCOLOR_OFF}\n\n" \
-                    "OK"
+                _op_func_return_code=$?
             else
-                printf "${SETCOLOR_ON_HIGHLIGHT}%s${SETCOLOR_OFF}" \
-                    "Result"
-                printf " ... ${SETCOLOR_ON_FAILURE}%s${SETCOLOR_OFF}\n\n" \
-                    "FAILED"
+                _op_func_return_code=$?
             fi
+
+            case "${_op_func_return_code}" in
+                0)
+                    printf "${SETCOLOR_ON_HIGHLIGHT}%s${SETCOLOR_OFF}" \
+                        "Result"
+                    printf " ... ${SETCOLOR_ON_OK}%s${SETCOLOR_OFF}\n\n" \
+                        "OK"
+                    ;;
+                1)
+                    printf "${SETCOLOR_ON_HIGHLIGHT}%s${SETCOLOR_OFF}" \
+                        "Result"
+                    printf " ... ${SETCOLOR_ON_FAILURE}%s${SETCOLOR_OFF}\n\n" \
+                        "FAILED"
+                    ;;
+                2)
+                    printf "${SETCOLOR_ON_HIGHLIGHT}%s${SETCOLOR_OFF}" \
+                        "Result"
+                    printf " ... ${SETCOLOR_ON_FAILURE}%s${SETCOLOR_OFF}\n\n" \
+                        "SKIPPED"
+                    ;;
+            esac
         else
             # run non-verbosely
             printf "${SETCOLOR_ON_HIGHLIGHT}%s${SETCOLOR_OFF}:" \
@@ -981,14 +1031,30 @@ run_ops()
             printf " ${SETCOLOR_ON_COMMAND}%-*s${SETCOLOR_OFF} ... " \
                 "$_max_oplength" \
                 "${_op}"
+
+            # if-wrap
             if _op_func_output=$(eval "op_${_op_func}" 2>&1) ; then
-                # shellcheck disable=SC2059
-                printf "${SETCOLOR_ON_OK}OK${SETCOLOR_OFF}\n"
+                _op_func_return_code=$?
             else
-                # shellcheck disable=SC2059
-                printf "${SETCOLOR_ON_FAILURE}FAILED${SETCOLOR_OFF}\n"
-                echo "$_op_func_output"
+                _op_func_return_code=$?
             fi
+
+            case "${_op_func_return_code}" in
+                0)
+                    # shellcheck disable=SC2059
+                    printf "${SETCOLOR_ON_OK}OK${SETCOLOR_OFF}\n"
+                    ;;
+                1)
+                    # shellcheck disable=SC2059
+                    printf "${SETCOLOR_ON_FAILURE}FAILED${SETCOLOR_OFF}\n"
+                    echo "$_op_func_output"
+                    ;;
+                2)
+                    # shellcheck disable=SC2059
+                    printf "${SETCOLOR_ON_FAILURE}SKIPPED${SETCOLOR_OFF}\n"
+                    echo "$_op_func_output"
+                    ;;
+            esac
         fi
     done
 }
@@ -1616,6 +1682,11 @@ op_user_account()
 (
     run_op() { echo "+ ${*}" ; "$@" ; }
 
+    if [ "${_ONE_VALID_AWK}" = 'NO' ] ; then
+        printf "[!] This test is skipped due to the incompatible awk implementation!\n"
+        return 2
+    fi
+
     # comb the list
     _keep_list=$(echo "$ARG_USERS_KEEP" | \
         sed -e 's/,/ /g' -e 's/[[:space:]]\+/\n/g' -e '/^$/d' | \
@@ -1770,6 +1841,11 @@ op_one_shell_history()
 op_one_group_account()
 (
     run_op() { echo "+ ${*}" ; "$@" ; }
+
+    if [ "${_ONE_VALID_AWK}" = 'NO' ] ; then
+        printf "[!] This test is skipped due to the incompatible awk implementation!\n"
+        return 2
+    fi
 
     case "$(uname | tr '[:upper:]' '[:lower:]')" in
         linux)
@@ -2012,6 +2088,8 @@ op_one_trim()
             # improvement for the future...
             #msg "Trim/discard the unused space"
 
+            # TODO: check awk sanity if used...
+
             #if command -v trim > /dev/null ; then
             #    _devs=$(< /etc/fstab awk '
             #        {
@@ -2204,6 +2282,8 @@ ARG_PASSWORD=$(parse_password_arguments "$ARG_PASSWORD")
 # execute the requested action
 case "$action" in
     '')
+        sanity_check
+
         # ask before running
         ask_to_run_sysprep
 
@@ -2220,6 +2300,8 @@ case "$action" in
         exit 0
         ;;
     operations)
+        sanity_check
+
         # ask before running
         ask_to_run_sysprep
 

--- a/targets.sh
+++ b/targets.sh
@@ -22,7 +22,7 @@ case "${TARGET}" in
         TYPE=${TYPE:-freebsd}
         EXT=${EXT:-txz}
         TAGS=${TAGS:-bsd bsd_rc one sysv}
-        DEPENDS=${DEPENDS:-sudo bash curl base64 ruby open-vm-tools-nox11}
+        DEPENDS=${DEPENDS:-sudo bash curl base64 ruby open-vm-tools-nox11 gawk}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-addon-context}
         CONFLICTS=${CONFLICTS:-${REPLACES} one-context-ec2}
@@ -38,7 +38,7 @@ case "${TARGET}" in
         RELSUFFIX=${RELSUFFIX:-.el6}
         TYPE=${TYPE:-rpm}
         TAGS=${TAGS:-rpm sysv one network-scripts}
-        DEPENDS=${DEPENDS:-util-linux-ng bash curl bind-utils cloud-utils-growpart dracut-modules-growroot parted ruby rubygem-json sudo shadow-utils openssh-server open-vm-tools qemu-guest-agent}
+        DEPENDS=${DEPENDS:-util-linux-ng bash curl bind-utils cloud-utils-growpart dracut-modules-growroot parted ruby rubygem-json sudo shadow-utils openssh-server open-vm-tools qemu-guest-agent gawk}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-cloud-init}
         CONFLICTS=${CONFLICTS:-${REPLACES} one-context-ec2}
@@ -54,7 +54,7 @@ case "${TARGET}" in
         RELSUFFIX=${RELSUFFIX:-.el6}
         TYPE=${TYPE:-rpm}
         TAGS=${TAGS:-rpm sysv ec2 network-scripts}
-        DEPENDS=${DEPENDS:-util-linux-ng bash curl bind-utils cloud-utils-growpart dracut-modules-growroot parted ruby rubygem-json sudo shadow-utils openssh-server}
+        DEPENDS=${DEPENDS:-util-linux-ng bash curl bind-utils cloud-utils-growpart dracut-modules-growroot parted ruby rubygem-json sudo shadow-utils openssh-server gawk}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-cloud-init}
         CONFLICTS=${CONFLICTS:-${REPLACES} one-context}
@@ -69,7 +69,7 @@ case "${TARGET}" in
         RELSUFFIX=${RELSUFFIX:-.el7}
         TYPE=${TYPE:-rpm}
         TAGS=${TAGS:-rpm systemd one network-scripts}
-        DEPENDS=${DEPENDS:-util-linux bash curl bind-utils cloud-utils-growpart parted ruby rubygem-json sudo shadow-utils openssh-server open-vm-tools qemu-guest-agent}
+        DEPENDS=${DEPENDS:-util-linux bash curl bind-utils cloud-utils-growpart parted ruby rubygem-json sudo shadow-utils openssh-server open-vm-tools qemu-guest-agent gawk}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-cloud-init}
         CONFLICTS=${CONFLICTS:-${REPLACES} one-context-ec2}
@@ -84,7 +84,7 @@ case "${TARGET}" in
         RELSUFFIX=${RELSUFFIX:-.el7}
         TYPE=${TYPE:-rpm}
         TAGS=${TAGS:-rpm systemd ec2 network-scripts}
-        DEPENDS=${DEPENDS:-util-linux bash curl bind-utils cloud-utils-growpart parted ruby rubygem-json sudo shadow-utils openssh-server}
+        DEPENDS=${DEPENDS:-util-linux bash curl bind-utils cloud-utils-growpart parted ruby rubygem-json sudo shadow-utils openssh-server gawk}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-cloud-init}
         CONFLICTS=${CONFLICTS:-${REPLACES} one-context}
@@ -99,7 +99,7 @@ case "${TARGET}" in
         RELSUFFIX=${RELSUFFIX:-.el8}
         TYPE=${TYPE:-rpm}
         TAGS=${TAGS:-rpm systemd one network-scripts}
-        DEPENDS=${DEPENDS:-util-linux bash curl bind-utils cloud-utils-growpart parted ruby rubygem-json sudo shadow-utils openssh-server open-vm-tools qemu-guest-agent network-scripts}
+        DEPENDS=${DEPENDS:-util-linux bash curl bind-utils cloud-utils-growpart parted ruby rubygem-json sudo shadow-utils openssh-server open-vm-tools qemu-guest-agent network-scripts gawk}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-cloud-init}
         CONFLICTS=${CONFLICTS:-${REPLACES} one-context-ec2}
@@ -114,7 +114,7 @@ case "${TARGET}" in
         RELSUFFIX=${RELSUFFIX:-.el8}
         TYPE=${TYPE:-rpm}
         TAGS=${TAGS:-rpm systemd ec2 network-scripts}
-        DEPENDS=${DEPENDS:-util-linux bash curl bind-utils cloud-utils-growpart parted ruby rubygem-json sudo shadow-utils openssh-server network-scripts}
+        DEPENDS=${DEPENDS:-util-linux bash curl bind-utils cloud-utils-growpart parted ruby rubygem-json sudo shadow-utils openssh-server network-scripts gawk}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-cloud-init}
         CONFLICTS=${CONFLICTS:-${REPLACES} one-context}
@@ -129,7 +129,7 @@ case "${TARGET}" in
         RELSUFFIX=${RELSUFFIX:-alt}
         TYPE=${TYPE:-rpm}
         TAGS=${TAGS:-rpm systemd one networkd}
-        DEPENDS=${DEPENDS:-bind-utils btrfs-progs cloud-utils-growpart curl e2fsprogs iproute2 openssl parted passwd qemu-guest-agent open-vm-tools ruby-json-pure sudo systemd-services wget which xfsprogs}
+        DEPENDS=${DEPENDS:-bind-utils btrfs-progs cloud-utils-growpart curl e2fsprogs iproute2 openssl parted passwd qemu-guest-agent open-vm-tools ruby-json-pure sudo systemd-services wget which xfsprogs gawk}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-cloud-init}
         CONFLICTS=${CONFLICTS:-${REPLACES} one-context-ec2}
@@ -145,7 +145,7 @@ case "${TARGET}" in
         RELSUFFIX=${RELSUFFIX:-.suse}
         TYPE=${TYPE:-rpm}
         TAGS=${TAGS:-rpm systemd one network-scripts}
-        DEPENDS=${DEPENDS:-util-linux bash curl bind-utils growpart parted parted ruby sudo shadow openssh open-vm-tools qemu-guest-agent} # rubygem-json}
+        DEPENDS=${DEPENDS:-util-linux bash curl bind-utils growpart parted parted ruby sudo shadow openssh open-vm-tools qemu-guest-agent gawk} # rubygem-json}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-cloud-init cloud-init-config-suse}
         CONFLICTS=${CONFLICTS:-${REPLACES} one-context-ec2}
@@ -160,7 +160,7 @@ case "${TARGET}" in
         RELSUFFIX=${RELSUFFIX:-.suse}
         TYPE=${TYPE:-rpm}
         TAGS=${TAGS:-rpm systemd ec2 network-scripts}
-        DEPENDS=${DEPENDS:-util-linux bash curl bind-utils growpart parted ruby sudo shadow openssh} # rubygem-json}
+        DEPENDS=${DEPENDS:-util-linux bash curl bind-utils growpart parted ruby sudo shadow openssh gawk} # rubygem-json}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-cloud-init cloud-init-config-suse}
         CONFLICTS=${CONFLICTS:-${REPLACES} one-context}
@@ -176,7 +176,7 @@ case "${TARGET}" in
         RELSUFFIX=${RELSUFFIX:-}
         TYPE=${TYPE:-deb}
         TAGS=${TAGS:-deb sysv systemd upstart one}
-        DEPENDS=${DEPENDS:-util-linux bash curl bind9-host cloud-utils parted ruby ifupdown|ifupdown2 acpid sudo passwd dbus openssh-server open-vm-tools qemu-guest-agent}
+        DEPENDS=${DEPENDS:-util-linux bash curl bind9-host cloud-utils parted ruby ifupdown|ifupdown2 acpid sudo passwd dbus openssh-server open-vm-tools qemu-guest-agent gawk}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-cloud-init}
         CONFLICTS=${CONFLICTS:-${REPLACES} one-context-ec2}
@@ -191,7 +191,7 @@ case "${TARGET}" in
         RELSUFFIX=${RELSUFFIX:-}
         TYPE=${TYPE:-deb}
         TAGS=${TAGS:-deb sysv systemd upstart ec2}
-        DEPENDS=${DEPENDS:-util-linux bash curl bind9-host cloud-utils parted ruby ifupdown|ifupdown2 sudo passwd dbus openssh-server resolvconf}
+        DEPENDS=${DEPENDS:-util-linux bash curl bind9-host cloud-utils parted ruby ifupdown|ifupdown2 sudo passwd dbus openssh-server resolvconf gawk}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-cloud-init}
         CONFLICTS=${CONFLICTS:-${REPLACES} one-context}
@@ -206,7 +206,7 @@ case "${TARGET}" in
         RELSUFFIX=${RELSUFFIX:-}
         TYPE=${TYPE:-apk}
         TAGS=${TAGS:-apk one}
-        DEPENDS=${DEPENDS:-util-linux bash curl udev sfdisk parted e2fsprogs-extra sudo shadow ruby ruby-json bind-tools openssh open-vm-tools qemu-guest-agent}
+        DEPENDS=${DEPENDS:-util-linux bash curl udev sfdisk parted e2fsprogs-extra sudo shadow ruby ruby-json bind-tools openssh open-vm-tools qemu-guest-agent gawk}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-}  #not respected
         CONFLICTS=${CONFLICTS:-one-context-ec2}
@@ -221,7 +221,7 @@ case "${TARGET}" in
         RELSUFFIX=${RELSUFFIX:-}
         TYPE=${TYPE:-apk}
         TAGS=${TAGS:-apk ec2}
-        DEPENDS=${DEPENDS:-util-linux bash curl udev sfdisk parted e2fsprogs-extra sudo shadow ruby ruby-json bind-tools openssh}
+        DEPENDS=${DEPENDS:-util-linux bash curl udev sfdisk parted e2fsprogs-extra sudo shadow ruby ruby-json bind-tools openssh gawk}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-}  #not respected
         CONFLICTS=${CONFLICTS:-one-context}
@@ -243,7 +243,7 @@ case "${TARGET}" in
         EXT=${EXT:-pkg.tar.xz}
         TAGS=${TAGS:-arch systemd one networkd}
         # mkinitcpio-growrootfs ruby-json
-        DEPENDS=${DEPENDS:-filesystem util-linux bash curl bind-tools ruby sudo shadow open-vm-tools qemu-guest-agent}
+        DEPENDS=${DEPENDS:-filesystem util-linux bash curl bind-tools ruby sudo shadow open-vm-tools qemu-guest-agent gawk}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-cloud-init}
         CONFLICTS=${CONFLICTS:-${REPLACES} one-context-ec2}


### PR DESCRIPTION
The default 'awk' _alternative_ on the Debian is an old mawk of version
1.3.3 with plenty of bugs and problems. One of them is the lack of
support for POSIX regex character classes which old mawk does not know
despite the fact that it does advertise a support for extended regex (as
egrep for example).

This was reported and fixed in 2009 with version of 1.3.4 but Debian is
still using the old unfixed version 1.3.3:
https://bugs.launchpad.net/ubuntu/+source/mawk/+bug/69724

This commit workaround this issue by simple test and possible abort if
the usage of an incompatible awk implementation is unreasonable - user
choice.

Note: Currently just only two optional (non-default) tests are skipped
due to this issue.

Signed-off-by: Petr Ospalý <pospaly@opennebula.io>

<!--//////////////////////////////////////////////////////////-->
<!-- Please note the pull request can be merged only if all   -->
<!-- commits are properly signed! Read the instructions here: -->
<!-- https://github.com/OpenNebula/one/wiki/Sign-Your-Work    -->
<!--//////////////////////////////////////////////////////////-->
