### PR TITLE
Add additional (Ubuntu) log files to be deleted.

### DIFF
--- a/src/usr/sbin/onesysprep
+++ b/src/usr/sbin/onesysprep
@@ -1445,6 +1445,8 @@ op_logfiles()
         /var/log/apt/* \
         /var/log/exim4/* \
         /var/log/ConsoleKit/* \
+        /var/log/landscape/* \
+        /var/log/unattended-upgrades/* \
         ;
 )
 


### PR DESCRIPTION
M #-: Add additional log files to be deleted.

Ubuntu systems have log files in /var/log/landscape and
/var/log/unattended-upgrades. The files in these directories
are not removed by the onesysprep tool. This patch add the
aforementioned directories.

Signed-off-by: Remy Zandwijk <remy@luckyhands.nl>

