### PR TITLE
F one-infra#39: Add weak dependency support

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -198,6 +198,8 @@ else
         --rpm-os linux \
         --rpm-summary "${SUMMARY}" \
         ${DEPENDS:+ --depends ${DEPENDS// / --depends }} \
+        ${RECOMMENDS:+ --rpm-tag Recommends:${RECOMMENDS// / --rpm-tag Recommends:}} \
+        ${RECOMMENDS:+ --deb-recommends ${RECOMMENDS// / --deb-recommends }} \
         ${REPLACES:+ --replaces ${REPLACES// / --replaces }} \
         ${CONFLICTS:+ --conflicts ${CONFLICTS// / --conflicts }} \
         ${PROVIDES:+ --provides ${PROVIDES// / --provides }} \

--- a/targets.sh
+++ b/targets.sh
@@ -53,7 +53,8 @@ case "${TARGET}" in
         RELSUFFIX=${RELSUFFIX:-.el7}
         TYPE=${TYPE:-rpm}
         TAGS=${TAGS:-linux rpm systemd one network-scripts}
-        DEPENDS=${DEPENDS:-util-linux bash curl bind-utils cloud-utils-growpart parted ruby rubygem-json sudo shadow-utils openssh-server open-vm-tools qemu-guest-agent gawk virt-what}
+        DEPENDS=${DEPENDS:-util-linux bash curl bind-utils cloud-utils-growpart parted ruby rubygem-json sudo shadow-utils openssh-server qemu-guest-agent gawk virt-what}
+        RECOMMENDS=${RECOMMENDS:-open-vm-tools}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-cloud-init}
         CONFLICTS=${CONFLICTS:-${REPLACES} one-context-ec2}
@@ -68,7 +69,8 @@ case "${TARGET}" in
         RELSUFFIX=${RELSUFFIX:-.el8}
         TYPE=${TYPE:-rpm}
         TAGS=${TAGS:-linux rpm systemd one network-scripts}
-        DEPENDS=${DEPENDS:-util-linux bash curl bind-utils cloud-utils-growpart parted ruby rubygem-json sudo shadow-utils openssh-server open-vm-tools qemu-guest-agent network-scripts gawk virt-what}
+        DEPENDS=${DEPENDS:-util-linux bash curl bind-utils cloud-utils-growpart parted ruby rubygem-json sudo shadow-utils openssh-server qemu-guest-agent network-scripts gawk virt-what}
+        RECOMMENDS=${RECOMMENDS:-open-vm-tools}
         PROVIDES=${PROVIDES:-}
         REPLACES=${REPLACES:-cloud-init}
         CONFLICTS=${CONFLICTS:-${REPLACES} one-context-ec2}


### PR DESCRIPTION
New variable RECOMMENDS can be used as a weak dependency list on rpm and
deb based distros.

The package open-vm-tools is moved to RECOMMENDS on el7 and el8 due to
the absence of arm64 version of these packages in RH distros.

Signed-off-by: Petr Ospalý <pospaly@opennebula.io>

<!--//////////////////////////////////////////////////////////-->
<!-- Please note the pull request can be merged only if all   -->
<!-- commits are properly signed! Read the instructions here: -->
<!-- https://github.com/OpenNebula/one/wiki/Sign-Your-Work    -->
<!--//////////////////////////////////////////////////////////-->