### PR TITLE
F #260: Allow not mounting Swap automatically

### DIFF
--- a/src/etc/one-context.d/loc-14-mount-swap##one
+++ b/src/etc/one-context.d/loc-14-mount-swap##one
@@ -21,6 +21,10 @@ if [ "$1" != 'local' ] ; then
     exit 0
 fi
 
+if [ "${DISABLE_SWAP}" == "true" ]; then
+    exit 0
+fi
+
 activate_swaps_linux() {
     SWAP_DRIVES=$(blkid -t TYPE="swap" -o device)
     for SWAP in $SWAP_DRIVES ; do
@@ -30,6 +34,6 @@ activate_swaps_linux() {
     done
 }
 
-if [ "$(uname -s)" = 'Linux' ] && [ "${DISABLE_SWAP}" != "true" ]; then
+if [ "$(uname -s)" = 'Linux' ]; then
     activate_swaps_linux
 fi

--- a/src/etc/one-context.d/loc-14-mount-swap##one
+++ b/src/etc/one-context.d/loc-14-mount-swap##one
@@ -30,6 +30,6 @@ activate_swaps_linux() {
     done
 }
 
-if [ "$(uname -s)" = 'Linux' ]; then
+if [ "$(uname -s)" = 'Linux' ] && [ "${DISABLE_SWAP}" != "true" ]; then
     activate_swaps_linux
 fi


### PR DESCRIPTION
<!--//////////////////////////////////////////////////////////-->
<!-- Please note the pull request can be merged only if all   -->
<!-- commits are properly signed! Read the instructions here: -->
<!-- https://github.com/OpenNebula/one/wiki/Sign-Your-Work    -->
<!--//////////////////////////////////////////////////////////-->

Changes proposed in this pull request:
- Allow user to provide a Context Variable called `DISABLE_SWAP` with the value `true` to prevent the `one-context.d` scripts to automatically try to mount the Swap file
