### PR TITLE
B #251: Enforce POSIX C locale

### DIFF
--- a/src/usr/sbin/one-contextd
+++ b/src/usr/sbin/one-contextd
@@ -18,6 +18,8 @@
 
 set -e
 
+export LANG=C.UTF-8
+
 TYPE="${1:-all}"  # local, online, network, all
 COMMAND="${2}"    # force, reconfigure?
 

--- a/src/usr/sbin/one-contextd
+++ b/src/usr/sbin/one-contextd
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # -------------------------------------------------------------------------- #
-# Copyright 2002-2021, OpenNebula Project, OpenNebula Systems                #
+# Copyright 2002-2022, OpenNebula Project, OpenNebula Systems                #
 #                                                                            #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may    #
 # not use this file except in compliance with the License. You may obtain    #
@@ -18,7 +18,22 @@
 
 set -e
 
-export LANG=C.UTF-8
+# Save original locale variables and enforce POSIX C locale
+#
+# We provide the user a way to fallback to the correct locale when a command
+# should or must respect system's locale by saving the original values into the
+# '_one_orig*' variables...
+
+export _one_orig_LANG="${LANG}"
+export _one_orig_LC_ALL="${LC_ALL}"
+export _one_orig_LC_COLLATE="${LC_COLLATE}"
+export _one_orig_LC_CTYPE="${LC_CTYPE}"
+export _one_orig_LC_MESSAGES="${LC_MESSAGES}"
+export _one_orig_LC_MONETARY="${LC_MONETARY}"
+export _one_orig_LC_NUMERIC="${LC_NUMERIC}"
+export _one_orig_LC_TIME="${LC_TIME}"
+export LANG=C
+export LC_ALL=C
 
 TYPE="${1:-all}"  # local, online, network, all
 COMMAND="${2}"    # force, reconfigure?


### PR DESCRIPTION
- Change the value of `LANG` to `C` (POSIX) which is more generic
- `LANG` can be insufficient and will not override `LC_TIME` for example if that was set
- `LC_ALL` will ensure that all categories of locale are POSIX C
- This commit also provides a way for the scripts to find the original locale via `_one_orig_*` variables if that would be needed