### PR TITLE
F #267: Add EL9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ List of tested platforms only:
 
 | Platform                        | Versions                                 |
 |---------------------------------|------------------------------------------|
-| AlmaLinux                       | 8                                        |
+| AlmaLinux                       | 8, 9                                     |
 | Alpine Linux                    | 3.13, 3.14, 3.15                         |
 | Amazon Linux                    | 2                                        |
 | CentOS                          | 7, 8 Stream                              |
@@ -87,6 +87,7 @@ Selectable configuration types and IP configuration methods are **supported only
 | openSUSE 15                                                   | `scripts`                                 |
 | RHEL-like 7 (CentOS, Oracle Linux)                            | `scripts`                                 |
 | RHEL-like 8 (CentOS, Oracle/Rocky/AlmaLinux)                  | `scripts`, `nm`, `networkd`               |
+| RHEL-like 9 (CentOS Stream 9, Oracle/Rocky/AlmaLinux)         | `nm`, `networkd`                          |
 | Ubuntu 18.04, 20.04, 21.10, 22.04                             | `interfaces`, `netplan`, `nm`, `networkd` |
 
 (other than listed platforms are not supported for using `NETCFG_TYPE` nor `METHOD`/`IP6_METHOD`!):

--- a/generate-all.sh
+++ b/generate-all.sh
@@ -3,7 +3,7 @@
 set -e
 
 export DATE=$(date +%Y%m%d)
-TARGETS='el6 el7 el8 alt suse deb alpine freebsd iso'
+TARGETS='el6 el7 el8 el9 alt suse deb alpine freebsd iso'
 
 for TARGET in $TARGETS; do
 	TARGET="${TARGET}" ./generate.sh

--- a/targets.sh
+++ b/targets.sh
@@ -80,6 +80,22 @@ case "${TARGET}" in
         POSTUP=${POSTUP:-pkg/postupgrade}
         ;;
 
+    'el9')
+        NAME=${NAME:-one-context}
+        RELSUFFIX=${RELSUFFIX:-.el9}
+        TYPE=${TYPE:-rpm}
+        TAGS=${TAGS:-linux rpm systemd one}
+        DEPENDS=${DEPENDS:-util-linux bash curl bind-utils cloud-utils-growpart parted ruby rubygem-json sudo shadow-utils openssh-server qemu-guest-agent gawk virt-what}
+        RECOMMENDS=${RECOMMENDS:-open-vm-tools}
+        PROVIDES=${PROVIDES:-}
+        REPLACES=${REPLACES:-cloud-init}
+        CONFLICTS=${CONFLICTS:-${REPLACES} one-context-ec2}
+        POSTIN=${POSTINST:-pkg/postinstall}
+        PREUN=${PREUN:-pkg/preuninstall}
+        POSTUN=${POSTUN:-pkg/postuninstall}
+        POSTUP=${POSTUP:-pkg/postupgrade}
+        ;;
+
     'alt')
         NAME=${NAME:-one-context}
         RELSUFFIX=${RELSUFFIX:-alt}


### PR DESCRIPTION
Since EL9 does not contain the legacy network scripts, add EL9 support
without network-scripts dependency

Tested on AlmaLinux OS 9 Beta 1 [x86_64](https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/) and [AArch64](https://repo.almalinux.org/almalinux/9/cloud/aarch64/images/) OpenNebula Images

Resolves #267 

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>

<!--//////////////////////////////////////////////////////////-->
<!-- Please note the pull request can be merged only if all   -->
<!-- commits are properly signed! Read the instructions here: -->
<!-- https://github.com/OpenNebula/one/wiki/Sign-Your-Work    -->
<!--//////////////////////////////////////////////////////////-->
