### PR TITLE
B #-: Avoid netplan race condition

### DIFF
--- a/src/etc/one-context.d/loc-10-network.d/netcfg-netplan
+++ b/src/etc/one-context.d/loc-10-network.d/netcfg-netplan
@@ -41,7 +41,7 @@ configure_network()
     # booting of current systems, so we execute netplan apply on the background
     case "${NETCFG_NETPLAN_RENDERER}" in
         ''|networkd)
-            nohup netplan apply &>/dev/null &
+            flock /var/run/one-context/netplan.lock nohup netplan apply &>/dev/null &
             ;;
     esac
 }
@@ -56,14 +56,14 @@ start_network()
     netplan generate
     nm_symlink_run_connections
     service networking start
-    netplan apply
+    flock /var/run/one-context/netplan.lock netplan apply
 }
 
 reload_network()
 {
     netplan generate
     nm_symlink_run_connections
-    netplan apply
+    flock /var/run/one-context/netplan.lock netplan apply
 }
 
 #


### PR DESCRIPTION
netplan NETCFG renderer tent to be unreliable in tests

While not 100% proven I assume the cause is a simultaneous run of `netplan apply` from configure_netowork (in the background) and again in reload_network