### PR TITLE
Support ID_LIKE in /etc/os-release if it exists

### DIFF
--- a/src/etc/one-context.d/loc-10-network
+++ b/src/etc/one-context.d/loc-10-network
@@ -29,32 +29,41 @@ if [ -z "${action}" ] ; then
 fi
 
 if [ -z "${NETCFG_TYPE}" ] ; then
-    case "${os_id}" in
-        alpine)
-            NETCFG_TYPE='interfaces'
-            ;;
-        altlinux)
-            NETCFG_TYPE='networkd nm'
-            ;;
-        debian|devuan|ubuntu)
-            NETCFG_TYPE='interfaces netplan nm networkd'
-            ;;
-        fedora|centos|rhel|almalinux|ol|rocky)
-            NETCFG_TYPE='scripts nm networkd'
-            ;;
-        opensuse*|sles|sled)
-            NETCFG_TYPE='scripts'
-            ;;
-        amzn)
-            NETCFG_TYPE='scripts'
-            ;;
-        freebsd)
-            NETCFG_TYPE='bsd'
-            ;;
-        *)
-            NETCFG_TYPE='none'
-            ;;
-    esac
+    for id in ${os_id}; do
+        case "${id}" in
+            alpine)
+                NETCFG_TYPE='interfaces'
+                break
+                ;;
+            altlinux)
+                NETCFG_TYPE='networkd nm'
+                break
+                ;;
+            debian|devuan|ubuntu)
+                NETCFG_TYPE='interfaces netplan nm networkd'
+                break
+                ;;
+            fedora|centos|rhel|almalinux|ol|rocky)
+                NETCFG_TYPE='scripts nm networkd'
+                break
+                ;;
+            opensuse*|sles|sled)
+                NETCFG_TYPE='scripts'
+                break
+                ;;
+            amzn)
+                NETCFG_TYPE='scripts'
+                break
+                ;;
+            freebsd)
+                NETCFG_TYPE='bsd'
+                break
+                ;;
+            *)
+                NETCFG_TYPE='none'
+                ;;
+        esac
+    done
 else
     # trim and lowercase
     NETCFG_TYPE=$(echo "$NETCFG_TYPE" | \

--- a/src/etc/one-context.d/loc-10-network.d/functions
+++ b/src/etc/one-context.d/loc-10-network.d/functions
@@ -198,9 +198,10 @@ detect_os()
 (
     if [ -f /etc/os-release ] ; then
         ID=
+        ID_LIKE=
         # shellcheck disable=SC1091
         . /etc/os-release
-        echo "$ID" | tr '[:upper:]' '[:lower:]'
+        echo "$ID $ID_LIKE" | tr '[:upper:]' '[:lower:]'
 
     # check for legacy RHEL/CentOS 6
     elif [ -f /etc/centos-release ]; then


### PR DESCRIPTION
 - Useful for unsupported distributions based on supported distributions
 
An example use case is we utilize CloudLinux for a handful of servers, a commercial distribution based on RHEL. Since CloudLinux isn't supported by OpenNebula officially, it breaks some context functions, such as the network, due to how OS detection works.

This change proposes the `detect_os` function used to determine which OS it's the script is being run on and also sends along the `ID_LIKE` variable in the `/etc/os-release` file if it exists. Then we can loop over the `ID_LIKE` distributions to see if anything matches if the `ID` field doesn't match a supported OS.

No other context scripts rely on the `detect_os` helper function, so it should be safe to adjust what it returns without breaking other context scripts.
