### PR TITLE
OpenNebula/addon-context-linux#286: Rework OS detection for unsupport…

### DIFF
--- a/src/etc/one-context.d/loc-10-network
+++ b/src/etc/one-context.d/loc-10-network
@@ -28,36 +28,34 @@ if [ -z "${action}" ] ; then
     action="configure"
 fi
 
+# update detect_os function if new distro is added
 if [ -z "${NETCFG_TYPE}" ] ; then
-    for id in ${os_id}; do
-        case "${id}" in
-            alpine)
-                NETCFG_TYPE='interfaces'
-                ;;
-            altlinux)
-                NETCFG_TYPE='networkd nm'
-                ;;
-            debian|devuan|ubuntu)
-                NETCFG_TYPE='interfaces netplan nm networkd'
-                ;;
-            fedora|centos|rhel|almalinux|ol|rocky)
-                NETCFG_TYPE='scripts nm networkd'
-                ;;
-            opensuse*|sles|sled)
-                NETCFG_TYPE='scripts'
-                ;;
-            amzn)
-                NETCFG_TYPE='scripts'
-                ;;
-            freebsd)
-                NETCFG_TYPE='bsd'
-                ;;
-            *)
-                NETCFG_TYPE='none'
-                ;;
-        esac
-        break
-    done
+    case "${os_id}" in
+        alpine)
+            NETCFG_TYPE='interfaces'
+            ;;
+        altlinux)
+            NETCFG_TYPE='networkd nm'
+            ;;
+        debian|devuan|ubuntu)
+            NETCFG_TYPE='interfaces netplan nm networkd'
+            ;;
+        fedora|centos|rhel|almalinux|ol|rocky)
+            NETCFG_TYPE='scripts nm networkd'
+            ;;
+        opensuse*|sles|sled)
+            NETCFG_TYPE='scripts'
+            ;;
+        amzn)
+            NETCFG_TYPE='scripts'
+            ;;
+        freebsd)
+            NETCFG_TYPE='bsd'
+            ;;
+        *)
+            NETCFG_TYPE='none'
+            ;;
+    esac
 else
     # trim and lowercase
     NETCFG_TYPE=$(echo "$NETCFG_TYPE" | \

--- a/src/etc/one-context.d/loc-10-network.d/functions
+++ b/src/etc/one-context.d/loc-10-network.d/functions
@@ -199,9 +199,21 @@ detect_os()
     if [ -f /etc/os-release ] ; then
         ID=
         ID_LIKE=
+        LINUX_ID=
         # shellcheck disable=SC1091
         . /etc/os-release
-        echo "$ID $ID_LIKE" | tr '[:upper:]' '[:lower:]'
+
+        case "$ID" in
+            # supported distros
+            alpine|altlinux|debian|devuan|ubuntu|fedora|centos|rhel|almalinux|ol|rocky|opensuse*|sles|sled|amzn|freebsd)
+                LINUX_ID=$ID
+                ;;
+            *)
+                LINUX_ID=$ID_LIKE
+                ;;
+        esac
+
+        echo "$LINUX_ID" | tr '[:upper:]' '[:lower:]'
 
     # check for legacy RHEL/CentOS 6
     elif [ -f /etc/centos-release ]; then


### PR DESCRIPTION
A bug was introduced with #286. Although the `os_detect` function was only used once, the variable using the output was used multiple times and the network config breaks on some distros because of the new variable format. 

![image](https://user-images.githubusercontent.com/16429804/236350435-34a7e5b8-fbe1-4f8b-9ec9-4affa0e1b4bb.png)

It went from being "${variable}" to "${variable1} ${variable2}" which is checked in several other functions other than the one that sets the NETCFG_TYPE, which was the only one updated.

The change now keeps the old format and uses the alternative detection ID_LIKE if the ID is not among the supported ones.