### PR TITLE
F OpenNebula/addon-context-linux#277 Fix onegate proxy static route

### DIFF
--- a/src/etc/one-context.d/loc-10-network.d/functions
+++ b/src/etc/one-context.d/loc-10-network.d/functions
@@ -599,8 +599,7 @@ get_onegate_ip() {
 		#Regular expression to match an IPv4 address
 		ipv4_regex="([0-9]{1,3}\.){3}[0-9]{1,3}"
 
-		export onegate_host
-		onegate_host=$(echo "$ONEGATE_ENDPOINT" | grep -oE "$ipv4_regex")
+		export onegate_host=$(echo "$ONEGATE_ENDPOINT" | grep -oE "$ipv4_regex")
 	fi
 }
 

--- a/src/etc/one-context.d/loc-10-network.d/functions
+++ b/src/etc/one-context.d/loc-10-network.d/functions
@@ -55,7 +55,7 @@ initialize_network()
     [ "${action}" = 'configure' ] || return 0
 
     export onegate_proxy_route_missing="yes" # flag route not setup
-    
+
     _context_interfaces=$(get_context_interfaces)
     _iface_mac=$(get_interface_mac)
 
@@ -595,16 +595,15 @@ is_link_local() {
 }
 
 get_onegate_ip() {
- if [[ -n $ONEGATE_ENDPOINT ]]; then
-	# Regular expression to match an IPv4 address
-	ipv4_regex="([0-9]{1,3}\.){3}[0-9]{1,3}"
+	if [[ -n $ONEGATE_ENDPOINT ]]; then
+		#Regular expression to match an IPv4 address
+		ipv4_regex="([0-9]{1,3}\.){3}[0-9]{1,3}"
 
-	export onegate_host=$(echo "$ONEGATE_ENDPOINT" | grep -oE "$ipv4_regex")
-
-	echo "$onegate_host"
- fi
+		export onegate_host
+		onegate_host=$(echo "$ONEGATE_ENDPOINT" | grep -oE "$ipv4_regex")
+	fi
 }
 
 add_onegate_proxy_route?() {
-    is_link_local "$(get_onegate_ip)" && [[ $onegate_proxy_route_missing == "yes" ]]
+    is_link_local "$onegate_host" && [[ $onegate_proxy_route_missing == "yes" ]]
 }

--- a/src/etc/one-context.d/loc-10-network.d/functions
+++ b/src/etc/one-context.d/loc-10-network.d/functions
@@ -54,6 +54,8 @@ initialize_network()
     # shellcheck disable=SC2154
     [ "${action}" = 'configure' ] || return 0
 
+    export onegate_proxy_route_missing="yes" # flag route not setup
+    
     _context_interfaces=$(get_context_interfaces)
     _iface_mac=$(get_interface_mac)
 

--- a/src/etc/one-context.d/loc-10-network.d/netcfg-bsd
+++ b/src/etc/one-context.d/loc-10-network.d/netcfg-bsd
@@ -163,7 +163,8 @@ gen_iface_conf()
     fi
 
     # Add ONEGATE Proxy static route
-    if [[ $(add_onegate_proxy_route?) ]]; then
+    get_onegate_ip
+    if add_onegate_proxy_route?; then
         route_name="r_onegateproxy"
 
         sed -i "s/${route_names}/${route_names} ${route_name}/g" "$routes_conf_path"

--- a/src/etc/one-context.d/loc-10-network.d/netcfg-interfaces
+++ b/src/etc/one-context.d/loc-10-network.d/netcfg-interfaces
@@ -176,7 +176,7 @@ EOT
 
     # Add ONEGATE Proxy static route
     if [[ $(add_onegate_proxy_route?) ]]; then
-        echo "  up ip route replace ${onegate_host} via ${dev}"
+        echo "  up ip route replace ${onegate_host} dev ${dev}"
 
         # Will make proxy static route only applicable to 1st interface
         unset onegate_proxy_route_missing
@@ -374,8 +374,6 @@ iface lo inet loopback
 EOT
 
     _context_interfaces=$(get_context_interfaces)
-
-    export onegate_proxy_route_missing="yes" # flag route not setup
 
     for _iface in $_context_interfaces; do
         setup_iface_vars "$_iface"

--- a/src/etc/one-context.d/loc-10-network.d/netcfg-interfaces
+++ b/src/etc/one-context.d/loc-10-network.d/netcfg-interfaces
@@ -175,7 +175,8 @@ EOT
     fi
 
     # Add ONEGATE Proxy static route
-    if [[ $(add_onegate_proxy_route?) ]]; then
+    get_onegate_ip
+    if add_onegate_proxy_route?; then
         echo "  up ip route replace ${onegate_host} dev ${dev}"
 
         # Will make proxy static route only applicable to 1st interface

--- a/src/etc/one-context.d/loc-10-network.d/netcfg-netplan
+++ b/src/etc/one-context.d/loc-10-network.d/netcfg-netplan
@@ -167,7 +167,8 @@ EOT
         fi
 
     # Add ONEGATE Proxy static route
-    if [[ $(add_onegate_proxy_route?) ]]; then
+    get_onegate_ip
+    if add_onegate_proxy_route?; then
         # ip route replace 169.254.16.9/32 via eth0
         cat <<EOT
         - to: "${onegate_host}"

--- a/src/etc/one-context.d/loc-10-network.d/netcfg-networkd
+++ b/src/etc/one-context.d/loc-10-network.d/netcfg-networkd
@@ -137,7 +137,8 @@ EOT
     fi
 
     # Add ONEGATE Proxy static route
-    if [[ $(add_onegate_proxy_route?) ]]; then
+    get_onegate_ip
+    if add_onegate_proxy_route?; then
         # ip route replace 169.254.16.9/32 via eth0
         echo "[Route]"
         echo "Destination=${onegate_host}"

--- a/src/etc/one-context.d/loc-10-network.d/netcfg-nm
+++ b/src/etc/one-context.d/loc-10-network.d/netcfg-nm
@@ -140,7 +140,8 @@ gen_iface_conf()
     fi
 
     # Add ONEGATE Proxy static route
-    if [[ $(add_onegate_proxy_route?) ]]; then
+    get_onegate_ip
+    if add_onegate_proxy_route?; then
         # ip route replace 169.254.16.9/32 via eth0
         nmcli con mod "$dev" +ipv4.routes "$onegate_host"
 

--- a/src/etc/one-context.d/loc-10-network.d/netcfg-scripts
+++ b/src/etc/one-context.d/loc-10-network.d/netcfg-scripts
@@ -141,7 +141,8 @@ EOT
     fi
 
     # Add ONEGATE Proxy static route
-    if [[ $(add_onegate_proxy_route?) ]]; then
+    get_onegate_ip
+    if add_onegate_proxy_route?; then
         route="${onegate_host} dev ${dev}"
         echo "$route" >> "${config_path}/route-${dev}"
 

--- a/src/etc/one-context.d/loc-10-network.d/netcfg-scripts
+++ b/src/etc/one-context.d/loc-10-network.d/netcfg-scripts
@@ -142,7 +142,7 @@ EOT
 
     # Add ONEGATE Proxy static route
     if [[ $(add_onegate_proxy_route?) ]]; then
-        route="${onegate_host} via ${dev}"
+        route="${onegate_host} dev ${dev}"
         echo "$route" >> "${config_path}/route-${dev}"
 
         # Will make proxy static route only applicable to 1st interface


### PR DESCRIPTION
- The flag was being set only for interfaces. Now it is called on the function every network renderer uses
- [This](https://github.com/OpenNebula/docs/commit/d01ad842e6f588cd84e49fd23528aa102c72ebea)
