### PR TITLE
F OpenNebula/addon-context-linux#277 cleaner code

### DIFF
--- a/src/etc/one-context.d/loc-10-network.d/functions
+++ b/src/etc/one-context.d/loc-10-network.d/functions
@@ -55,6 +55,7 @@ initialize_network()
     [ "${action}" = 'configure' ] || return 0
 
     export onegate_proxy_route_missing="yes" # flag route not setup
+    get_onegate_ip
 
     _context_interfaces=$(get_context_interfaces)
     _iface_mac=$(get_interface_mac)
@@ -596,13 +597,13 @@ is_link_local() {
 
 get_onegate_ip() {
 	if [[ -n $ONEGATE_ENDPOINT ]]; then
-		#Regular expression to match an IPv4 address
+		# Regular expression to match an IPv4 address
 		ipv4_regex="([0-9]{1,3}\.){3}[0-9]{1,3}"
 
 		export onegate_host=$(echo "$ONEGATE_ENDPOINT" | grep -oE "$ipv4_regex")
 	fi
 }
 
-add_onegate_proxy_route?() {
+missing_onegate_proxy_route() {
     is_link_local "$onegate_host" && [[ $onegate_proxy_route_missing == "yes" ]]
 }

--- a/src/etc/one-context.d/loc-10-network.d/netcfg-bsd
+++ b/src/etc/one-context.d/loc-10-network.d/netcfg-bsd
@@ -153,7 +153,7 @@ gen_iface_conf()
             index+=1
         done
 
-                                    # remove last whitespace
+        # remove last whitespace
         echo -e "static_routes=\"$(echo "$route_names" | xargs)\"" >>$routes_conf_path
 
         for route_conf in "${routes_conf[@]}"; do
@@ -162,18 +162,15 @@ gen_iface_conf()
 
     fi
 
-    # Add ONEGATE Proxy static route
-    get_onegate_ip
-    if add_onegate_proxy_route?; then
+    # Add ONEGATE Proxy static route ip route replace 169.254.16.9 dev eth0
+    if missing_onegate_proxy_route; then
         route_name="r_onegateproxy"
 
         sed -i "s/${route_names}/${route_names} ${route_name}/g" "$routes_conf_path"
-        # ip route replace 169.254.16.9/32 via eth0
         route_conf="route_${route_name}=\"-host ${onegate_host} -iface ${dev}\""
 
         echo -e "$route_conf\n" >> $routes_conf_path
 
-        # Will make proxy static route only applicable to 1st interface
         unset onegate_proxy_route_missing
     fi
 }

--- a/src/etc/one-context.d/loc-10-network.d/netcfg-interfaces
+++ b/src/etc/one-context.d/loc-10-network.d/netcfg-interfaces
@@ -174,12 +174,10 @@ EOT
 
     fi
 
-    # Add ONEGATE Proxy static route
-    get_onegate_ip
-    if add_onegate_proxy_route?; then
+    # Add ONEGATE Proxy static route ip route replace 169.254.16.9 dev eth0
+    if missing_onegate_proxy_route; then
         echo "  up ip route replace ${onegate_host} dev ${dev}"
 
-        # Will make proxy static route only applicable to 1st interface
         unset onegate_proxy_route_missing
     fi
 

--- a/src/etc/one-context.d/loc-10-network.d/netcfg-netplan
+++ b/src/etc/one-context.d/loc-10-network.d/netcfg-netplan
@@ -166,10 +166,8 @@ EOT
 
         fi
 
-    # Add ONEGATE Proxy static route
-    get_onegate_ip
-    if add_onegate_proxy_route?; then
-        # ip route replace 169.254.16.9/32 via eth0
+    # Add ONEGATE Proxy static route ip route replace 169.254.16.9 dev eth0
+    if missing_onegate_proxy_route; then
         cat <<EOT
         - to: "${onegate_host}"
           scope: link

--- a/src/etc/one-context.d/loc-10-network.d/netcfg-networkd
+++ b/src/etc/one-context.d/loc-10-network.d/netcfg-networkd
@@ -136,10 +136,8 @@ EOT
 
     fi
 
-    # Add ONEGATE Proxy static route
-    get_onegate_ip
-    if add_onegate_proxy_route?; then
-        # ip route replace 169.254.16.9/32 via eth0
+    # Add ONEGATE Proxy static route ip route replace 169.254.16.9 dev eth0
+    if missing_onegate_proxy_route; then
         echo "[Route]"
         echo "Destination=${onegate_host}"
         echo "Scope=link"

--- a/src/etc/one-context.d/loc-10-network.d/netcfg-nm
+++ b/src/etc/one-context.d/loc-10-network.d/netcfg-nm
@@ -261,6 +261,11 @@ gen_network_configuration()
 {
     _context_interfaces=$(get_context_interfaces)
 
+    # nm renderer is required_context_type=online and it skips initialize_network
+    # this flag is set for all other renderers in there
+    export onegate_proxy_route_missing="yes" # flag route not setup
+    get_onegate_ip
+
     for _iface in $_context_interfaces; do
         setup_iface_vars "$_iface"
 

--- a/src/etc/one-context.d/loc-10-network.d/netcfg-nm
+++ b/src/etc/one-context.d/loc-10-network.d/netcfg-nm
@@ -139,10 +139,8 @@ gen_iface_conf()
 
     fi
 
-    # Add ONEGATE Proxy static route
-    get_onegate_ip
-    if add_onegate_proxy_route?; then
-        # ip route replace 169.254.16.9/32 via eth0
+    # Add ONEGATE Proxy static route ip route replace 169.254.16.9 dev eth0
+    if missing_onegate_proxy_route; then
         nmcli con mod "$dev" +ipv4.routes "$onegate_host"
 
         unset onegate_proxy_route_missing

--- a/src/etc/one-context.d/loc-10-network.d/netcfg-scripts
+++ b/src/etc/one-context.d/loc-10-network.d/netcfg-scripts
@@ -140,13 +140,11 @@ EOT
 
     fi
 
-    # Add ONEGATE Proxy static route
-    get_onegate_ip
-    if add_onegate_proxy_route?; then
+    # Add ONEGATE Proxy static route ip route replace 169.254.16.9 dev eth0
+    if missing_onegate_proxy_route; then
         route="${onegate_host} dev ${dev}"
         echo "$route" >> "${config_path}/route-${dev}"
 
-        # Will make proxy static route only applicable to 1st interface
         unset onegate_proxy_route_missing
     fi
 


### PR DESCRIPTION
Minor code improvements. Similar to setting the flag

```
export onegate_proxy_route_missing="yes" # flag route not setup
```

the onegate_ip is now read in only one place 