### PR TITLE
M #: Ensure proper network restart for alpine 3.16+

### DIFF
--- a/src/etc/one-context.d/loc-10-network.d/netcfg-interfaces
+++ b/src/etc/one-context.d/loc-10-network.d/netcfg-interfaces
@@ -46,13 +46,7 @@ stop_network()
         alpine)
             service networking stop || true
 
-            # took from find_ifaces in the networking service
-            _ifaces=$(\
-                awk '$1 == "auto" {
-                    for (i = 2; i <= NF; i = i + 1) printf("%s ", $i)
-                    }' /etc/network/interfaces)
-
-            for _iface in $_ifaces; do
+            for _iface in $(get_interfaces); do
                 if [ "${_iface}" != 'lo' ]; then
                     /sbin/ip link set dev "${_iface}" down || true
                     /sbin/ip addr flush dev "${_iface}" || true
@@ -64,9 +58,7 @@ stop_network()
                 return 0
             fi
 
-            _ifaces=$(/sbin/ifquery --list -a)
-
-            for _iface in $_ifaces; do
+            for _iface in $(get_interfaces); do
                 if [ "${_iface}" != 'lo' ] ; then
                     /sbin/ifdown "${_iface}"
                     /sbin/ip link set dev "${_iface}" down || true
@@ -85,6 +77,15 @@ start_network()
     case "${os_id}" in
         alpine)
             service networking start
+
+            # alpine 3.16+ might fail to set the interface configuration of an interface that was removed
+            # from /etc/network/interfaces. This results in the interface having a definition
+            # in the configuration file, but no actual interface configuration.
+
+            for _iface in $(get_interfaces); do
+                ip link show "$_iface"  | grep -q 'state DOWN' && service networking restart && break
+            done
+
             ;;
         debian|ubuntu|devuan)
             if [ -f "/usr/sbin/ifreload" ] ; then
@@ -92,9 +93,7 @@ start_network()
                 return 0
             fi
 
-            _ifaces=$(/sbin/ifquery --list -a)
-
-            for _iface in $_ifaces; do
+            for _iface in $(get_interfaces); do
                 /sbin/ifup "${_iface}"
             done
             ;;
@@ -423,4 +422,9 @@ EOT
             echo "source /etc/network/interfaces.d/*.cfg"
             ;;
     esac
+}
+
+# took from find_ifaces in the networking service
+get_interfaces() {
+    /sbin/ifquery --list -a
 }


### PR DESCRIPTION
Fixes

```
375. Contextualization image Alpine 3.17 on KVM common (1) doesn't ping detached NIC alias [Alpine 3.17]
Frontends: alma8-context-kvm-6-7-jnks339-0.test

reached timeout, last state was false  while expected true
At ./spec/context/linux/network.rb:274

376. Contextualization image Alpine 3.17 on KVM common (1) doesn't have new NIC in guest [Alpine 3.17]
Frontends: alma8-context-kvm-6-7-jnks339-0.test

reached timeout, last state was false CLITester::VM(0) while expected true
At ./spec/context/linux/network.rb:283

377. Contextualization image Alpine 3.17 on KVM common (1) waits for contextualization [Alpine 3.17]
Frontends: alma8-context-kvm-6-7-jnks339-0.test

reached timeout, last state was false  while expected true
At ./spec/context/common.rb:214

378. Contextualization image Alpine 3.16 on KVM common (1) doesn't ping detached NIC alias [Alpine 3.16]
Frontends: alma8-context-kvm-6-7-jnks339-0.test

reached timeout, last state was false  while expected true
At ./spec/context/linux/network.rb:274

379. Contextualization image Alpine 3.16 on KVM common (1) doesn't have new NIC in guest [Alpine 3.16]
Frontends: alma8-context-kvm-6-7-jnks339-0.test

reached timeout, last state was false CLITester::VM(1) while expected true
At ./spec/context/linux/network.rb:283

380. Contextualization image Alpine 3.16 on KVM common (1) waits for contextualization [Alpine 3.16]
Frontends: alma8-context-kvm-6-7-jnks339-0.test

reached timeout, last state was false  while expected true
At ./spec/context/common.rb:214
```

Problem is after detaching the NIC alias, the parent interface doesn't get reconfigured and remains in DOWN state. Issuing a `service networking restart` does the trick.