### PR TITLE
B OpenNebula/one#6174: Consider /etc/hosts being empty

### DIFF
--- a/src/etc/one-context.d/net-15-hostname
+++ b/src/etc/one-context.d/net-15-hostname
@@ -116,7 +116,7 @@ function update_hosts() {
     elif grep -qE "[[:space:]]${name}([[:space:]]|#|\$)" /etc/hosts; then
         eval "${SED_I} -re \"s/^.*[[:space:]]${name}([[:space:]#].*|$)/${entry}/\" /etc/hosts"
     # create new entry
-    elif [ -f /etc/hosts ]; then
+    elif [ -s /etc/hosts ]; then
         # In FreeBSD, sed doesn't interpret \n. We put a real newline.
         eval "${SED_I} -e \"1s/^/${entry}\"$'\\\\\n/' /etc/hosts"
     else

--- a/src/etc/one-context.d/net-15-hostname
+++ b/src/etc/one-context.d/net-15-hostname
@@ -151,15 +151,10 @@ if [ -n "${name}" ]; then
     # split host and domain names
     hostname=${name%%.*}
     domain=${name#*.}
-    if [ "x${domain}" = "x${hostname}" ]; then
-        domain=''
-    fi
 
-    if [ -n "${domain}" ]; then
-        set_domainname "${domain}"
-    fi
+    [ "$domain" = "$hostname" ] && domain=''
+    [ -n "${domain}" ] && set_domainname "${domain}"
 
-    # FreeBSD
     if [ "${_kernel}" = 'FreeBSD' ]; then
         set_hostname "${name}"
     else
@@ -169,20 +164,17 @@ if [ -n "${name}" ]; then
     if [ -n "${DNS_HOSTNAME}" ]; then
         host_ip=$first_ip
     else
+        name_ip=$(get_dns_name "${name}")
+
         # If selected hostname resolves on first IP,
         # use first IP for local hostname in /etc/hosts.
         # Otherwise use loopback IP.
-        name_ip=$(get_dns_name "${name}")
-        if [ "x${first_ip}" = "x${name_ip}" ]; then
+        if [ "$first_ip" = "$name_ip" ]; then
             host_ip=$first_ip
-        elif [ -f /etc/debian_version ]; then
-            host_ip='127.0.1.1'
         else
             host_ip='127.0.0.1'
         fi
     fi
 
-    if [ -n "${host_ip}" ]; then
-        update_hosts "${host_ip}" "${name}" "${hostname}"
-    fi
+    [ -n "${host_ip}" ] && update_hosts "${host_ip}" "${name}" "${hostname}"
 fi


### PR DESCRIPTION
populating `/etc/hosts` fails on DockerHub images because the file exists, but it is empty. So this condition triggers

```
elif [ -f /etc/hosts ]; then
        # In FreeBSD, sed doesn't interpret \n. We put a real newline.
        eval "${SED_I} -e \"1s/^/${entry}\"$'\\\\\n/' /etc/hosts"
```

and nothing happens. Now it is `-s` which will check both that the file exists and is not empty. When empty, next condition (else) will be checked and the entry will be forcibly written.

Some linting as well

Closes OpenNebula/one#6174

No doc PR required since it is a context problem. When the release is made it will be added to the context changelog